### PR TITLE
Histogram3d fix

### DIFF
--- a/yrt-pet/include/datastruct/projection/Histogram3D.hpp
+++ b/yrt-pet/include/datastruct/projection/Histogram3D.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "datastruct/PluginFramework.hpp"
+#include "datastruct/parallel_hashmap/phmap.h"
 #include "datastruct/projection/Histogram.hpp"
 #include "datastruct/scanner/Scanner.hpp"
 #include "utils/Array.hpp"
@@ -101,8 +102,8 @@ public:
 
 protected:
 	std::unique_ptr<Array3DBase<float>> mp_data;
-	std::unordered_map<det_pair_t, DetRingCoordinates, HashDetPair,
-	                   EqualDetPair>
+	phmap::flat_hash_map<det_pair_t, DetRingCoordinates, HashDetPair,
+	                     EqualDetPair>
 	    m_ringMap;
 	size_t m_rCut;
 	size_t m_numDOIPoss;   // Number of DOI combinations (ex: 2 doi -> 4 lor

--- a/yrt-pet/include/utils/Utilities.hpp
+++ b/yrt-pet/include/utils/Utilities.hpp
@@ -24,6 +24,12 @@ namespace Util
 	std::vector<std::string> split(const std::string str,
 	                               const std::string regex_str);
 
+	// ----------------- Math -----------------------------
+	inline int64_t positiveModulo(int64_t i, int64_t n)
+	{
+		return (i % n + n) % n;
+	}
+
 	// ----------------- Bit manipulation -----------------
 
 	// This generates a mask of all 1s from bits at position pLSBLimit to

--- a/yrt-pet/src/datastruct/projection/ProjectionData.cpp
+++ b/yrt-pet/src/datastruct/projection/ProjectionData.cpp
@@ -223,6 +223,7 @@ const Scanner& ProjectionData::getScanner() const
 	return mr_scanner;
 }
 
+// Note: If a bin is disabled, this should return {0, 0}
 det_pair_t ProjectionData::getDetectorPair(bin_t id) const
 {
 	return {getDetector1(id), getDetector2(id)};

--- a/yrt-pet/src/datastruct/scanner/Scanner.cpp
+++ b/yrt-pet/src/datastruct/scanner/Scanner.cpp
@@ -249,6 +249,8 @@ void Scanner::readFromString(const std::string& fileContents)
 	ASSERT_MSG(
 	    maxRingDiff < numRings,
 	    "Maximum Ring difference has to be lower than the number of rings");
+
+	ASSERT_MSG(minAngDiff > 0, "Minimum angle difference has to be non-zero");
 }
 
 std::string Scanner::getScannerPath() const

--- a/yrt-pet/unit_tests/datastruct/test_Histogram3D.cpp
+++ b/yrt-pet/unit_tests/datastruct/test_Histogram3D.cpp
@@ -7,19 +7,21 @@
 
 #include "datastruct/projection/Histogram3D.hpp"
 #include "datastruct/projection/ListModeLUT.hpp"
+#include "datastruct/scanner/DetRegular.hpp"
 #include "test_utils.hpp"
 #include "utils/ReconstructionUtils.hpp"
-
 
 bool check_coords(std::array<coord_t, 3> c1, std::array<coord_t, 3> c2)
 {
 	return (c1[0] == c2[0] && c1[1] == c2[1] && c1[2] == c2[2]);
 }
+
 bool check_det_pairs(det_pair_t p1, det_pair_t p2)
 {
 	return (p1.d1 == p2.d1 && p1.d2 == p2.d2) ||
 	       (p1.d1 == p2.d2 && p1.d2 == p2.d1);
 }
+
 bool compare_det_pairs(det_pair_t detPair1, det_pair_t detPair2)
 {
 	det_pair_t p1 = detPair1;
@@ -57,6 +59,7 @@ bool compare_det_pairs(det_pair_t detPair1, det_pair_t detPair2)
 		}
 	}
 }
+
 bool compare_coords(std::array<coord_t, 3> c1, std::array<coord_t, 3> c2)
 {
 	if (c1[2] < c2[2])
@@ -96,199 +99,275 @@ bool compare_coords(std::array<coord_t, 3> c1, std::array<coord_t, 3> c2)
 	}
 }
 
+auto getDetectorPositionInScanner(const Scanner& scanner, det_id_t d)
+{
+	int64_t doi = d / (scanner.numRings * scanner.detsPerRing);
+	int64_t ring = (d - doi * scanner.detsPerRing * scanner.numRings) /
+	               scanner.detsPerRing;
+	int64_t posInRing =
+	    (d - (ring + doi * scanner.numRings) * scanner.detsPerRing) %
+	    scanner.detsPerRing;
+	return std::make_tuple(doi, ring, posInRing);
+}
+
 TEST_CASE("histo3d", "[histo]")
 {
-	// TODO: Randomize scanner generation
-	auto scanner = TestUtils::makeScanner();
+	std::default_random_engine engine(
+	    static_cast<unsigned int>(std::time(nullptr)));
 
-	size_t n_total_detectors =
-	    scanner->numDOI * scanner->numRings * scanner->detsPerRing;
-	auto histo3d = std::make_unique<Histogram3DOwned>(*scanner);
+	std::uniform_int_distribution<size_t> numRingsDistribution(1, 15);
+	std::uniform_int_distribution<size_t> numDOIDistribution(1, 4);
+	// detsPerRing is forced to be an even number here (from 2 to 100 crystals)
+	std::uniform_int_distribution<size_t> halfDetsPerRingDistribution(1, 50);
 
-	SECTION("histo3d-sizes")
+	constexpr int NumTrials = 25;
+
+	for (int trial = 0; trial < NumTrials; trial++)
 	{
-		REQUIRE(histo3d->numR == 76);  // 4*(48/2+1-6)
-		REQUIRE(histo3d->numPhi == 48); // 48 detectors
-		REQUIRE(histo3d->numZBin == 132);
-	}
+		size_t numDOI = numDOIDistribution(engine);
+		size_t numRings = numRingsDistribution(engine);
+		size_t detsPerRing = halfDetsPerRingDistribution(engine) * 2ull;
 
-	SECTION("histo3d-binIds")
-	{
-		for (bin_t binId = 0; binId < histo3d->count(); binId++)
+		std::uniform_int_distribution<size_t> minAngDiffDistribution(
+		    1, detsPerRing / 2);
+		size_t minAngDiff = minAngDiffDistribution(engine);
+		size_t maxRingDiff;
+		if (numRings > 1)
+		{
+			std::uniform_int_distribution<size_t> maxRingDiffDistribution(
+			    0, numRings - 1);
+			maxRingDiff = maxRingDiffDistribution(engine);
+		}
+		else
+		{
+			maxRingDiff = 0;
+		}
+
+		// Create scanner
+		auto scanner = std::make_unique<Scanner>(
+		    "FakeScanner", 200, 1, 1, 10, 200, detsPerRing, numRings, numDOI,
+		    maxRingDiff, minAngDiff, 2);
+		const auto detRegular = std::make_shared<DetRegular>(scanner.get());
+		detRegular->generateLUT();
+		scanner->setDetectorSetup(detRegular);
+
+		size_t numDets =
+		    scanner->numDOI * scanner->numRings * scanner->detsPerRing;
+		auto histo3d = std::make_unique<Histogram3DOwned>(*scanner);
+
+		SECTION("histo3d-binIds-trial-" + std::to_string(trial + 1))
+		{
+			for (bin_t binId = 0; binId < histo3d->count(); binId++)
+			{
+				coord_t r, phi, z_bin;
+				histo3d->getCoordsFromBinId(binId, r, phi, z_bin);
+				bin_t supposedBin = histo3d->getBinIdFromCoords(r, phi, z_bin);
+				REQUIRE(supposedBin == binId);
+			}
+		}
+
+		SECTION("histo3d-coords-binning-trial-" + std::to_string(trial + 1))
 		{
 			coord_t r, phi, z_bin;
-			histo3d->getCoordsFromBinId(binId, r, phi, z_bin);
-			bin_t supposedBin = histo3d->getBinIdFromCoords(r, phi, z_bin);
-			REQUIRE(supposedBin == binId);
-		}
-	}
-
-	SECTION("histo3d-coords-binning")
-	{
-		coord_t r, phi, z_bin;
-		for (r = 0; r < histo3d->numR; r++)
-		{
-			for (phi = 0; phi < histo3d->numPhi; phi++)
+			for (r = 0; r < histo3d->numR; r++)
 			{
-				for (z_bin = 0; z_bin < histo3d->numZBin; z_bin++)
+				for (phi = 0; phi < histo3d->numPhi; phi++)
 				{
-					det_id_t d1, d2;
-					coord_t r_supp, phi_supp, z_bin_supp;
-					histo3d->getDetPairFromCoords(r, phi, z_bin, d1, d2);
-					histo3d->getCoordsFromDetPair(d1, d2, r_supp, phi_supp,
-					                              z_bin_supp);
-					det_id_t d1_supp, d2_supp;
-					histo3d->getDetPairFromCoords(r_supp, phi_supp, z_bin_supp,
-					                              d1_supp, d2_supp);
+					for (z_bin = 0; z_bin < histo3d->numZBin; z_bin++)
+					{
+						det_id_t d1, d2;
+						coord_t r_supp, phi_supp, z_bin_supp;
+						histo3d->getDetPairFromCoords(r, phi, z_bin, d1, d2);
+						if (d1 == 0 && d2 == 0)
+						{
+							// Disabled bin
+							continue;
+						}
+						histo3d->getCoordsFromDetPair(d1, d2, r_supp, phi_supp,
+						                              z_bin_supp);
+						det_id_t d1_supp, d2_supp;
+						histo3d->getDetPairFromCoords(
+						    r_supp, phi_supp, z_bin_supp, d1_supp, d2_supp);
 
-					bool check = (d1_supp == d1 && d2_supp == d2) ||
-					             (d1_supp == d2 && d2_supp == d1);
-					REQUIRE(check);
-					REQUIRE(d1 < n_total_detectors);
-					REQUIRE(d2 < n_total_detectors);
+						bool check = (d1_supp == d1 && d2_supp == d2) ||
+						             (d1_supp == d2 && d2_supp == d1);
+						REQUIRE(check);
+						REQUIRE(d1 < numDets);
+						REQUIRE(d2 < numDets);
+					}
 				}
 			}
 		}
-	}
 
-	SECTION("histo3d-detector-swap")
-	{
-		coord_t r, phi, z_bin;
-		for (r = 0; r < histo3d->numR; r++)
+		SECTION("histo3d-detector-swap-trial-" + std::to_string(trial + 1))
 		{
-			for (phi = 0; phi < histo3d->numPhi; phi++)
+			coord_t r, phi, z_bin;
+			for (r = 0; r < histo3d->numR; r++)
 			{
-				for (z_bin = 0; z_bin < histo3d->numZBin; z_bin++)
+				for (phi = 0; phi < histo3d->numPhi; phi++)
 				{
-					det_id_t d1, d2;
-					coord_t r_supp, phi_supp, z_bin_supp;
-					histo3d->getDetPairFromCoords(r, phi, z_bin, d1, d2);
-					histo3d->getCoordsFromDetPair(d2, d1, r_supp, phi_supp,
-					                              z_bin_supp);
-					REQUIRE(r_supp == r);
-					REQUIRE(phi_supp == phi);
-					REQUIRE(z_bin_supp == z_bin);
+					for (z_bin = 0; z_bin < histo3d->numZBin; z_bin++)
+					{
+						det_id_t d1, d2;
+						coord_t r_supp, phi_supp, z_bin_supp;
+						histo3d->getDetPairFromCoords(r, phi, z_bin, d1, d2);
+						if (d1 == 0 && d2 == 0)
+						{
+							// Disabled bin
+							continue;
+						}
+						histo3d->getCoordsFromDetPair(d2, d1, r_supp, phi_supp,
+						                              z_bin_supp);
+						CHECK(r_supp == r);
+						CHECK(phi_supp == phi);
+						CHECK(z_bin_supp == z_bin);
+					}
 				}
 			}
 		}
-	}
 
-
-	SECTION("histo3d-coords-uniqueness")
-	{
-		std::vector<std::array<coord_t, 3>> all_coords;
-
-		for (det_id_t d1 = 0; d1 < n_total_detectors; d1++)
+		SECTION("histo3d-coords-uniqueness-trial-" + std::to_string(trial + 1))
 		{
-			for (det_id_t d2 = d1 + 1; d2 < n_total_detectors; d2++)
+			std::vector<std::array<coord_t, 3>> all_coords;
+
+			for (det_id_t d1 = 0; d1 < numDets; d1++)
 			{
-				int d1_ring = d1 % (scanner->detsPerRing);
-				int d2_ring = d2 % (scanner->detsPerRing);
-				int diff = std::abs(d1_ring - d2_ring);
-				diff = (diff < static_cast<int>(scanner->detsPerRing / 2)) ?
-				           diff :
-				           scanner->detsPerRing - diff;
-				if (diff < static_cast<int>(scanner->minAngDiff))
+				for (det_id_t d2 = d1 + 1; d2 < numDets; d2++)
 				{
+					int d1_ring = d1 % (scanner->detsPerRing);
+					int d2_ring = d2 % (scanner->detsPerRing);
+					int diff = std::abs(d1_ring - d2_ring);
+					diff = (diff < static_cast<int>(scanner->detsPerRing / 2)) ?
+					           diff :
+					           scanner->detsPerRing - diff;
+					if (diff < static_cast<int>(scanner->minAngDiff))
+					{
+						continue;
+					}
+					int z1 =
+					    (d1 / (scanner->detsPerRing)) % (scanner->numRings);
+					int z2 =
+					    (d2 / (scanner->detsPerRing)) % (scanner->numRings);
+					if (std::abs(z1 - z2) > scanner->maxRingDiff)
+					{
+						continue;
+					}
+
+					coord_t r, phi, z_bin;
+					histo3d->getCoordsFromDetPair(d1, d2, r, phi, z_bin);
+					all_coords.push_back({r, phi, z_bin});
+				}
+			}
+			std::sort(std::begin(all_coords), std::end(all_coords),
+			          compare_coords);
+			auto u = std::unique(std::begin(all_coords), std::end(all_coords),
+			                     check_coords);
+			bool containsDuplicate = u != std::end(all_coords);
+			REQUIRE(!containsDuplicate);
+		}
+
+		SECTION("histo3d-detector-pairs-uniqueness-trial-" +
+		        std::to_string(trial + 1))
+		{
+			std::vector<det_pair_t> allDetPairs;
+
+			const size_t numBins = histo3d->count();
+			allDetPairs.reserve(numBins);
+
+			for (bin_t binId = 0; binId < numBins; binId++)
+			{
+				det_pair_t currPair = histo3d->getDetectorPair(binId);
+
+				if (currPair.d1 == 0 && currPair.d2 == 0)
+				{
+					// Disabled bin;
 					continue;
 				}
-				int z1 = (d1 / (scanner->detsPerRing)) % (scanner->numRings);
-				int z2 = (d2 / (scanner->detsPerRing)) % (scanner->numRings);
-				if (std::abs(z1 - z2) > scanner->maxRingDiff)
-				{
-					continue;
-				}
-
-				coord_t r, phi, z_bin;
-				histo3d->getCoordsFromDetPair(d1, d2, r, phi, z_bin);
-				all_coords.push_back({r, phi, z_bin});
+				allDetPairs.emplace_back(currPair);
 			}
-		}
-		std::sort(std::begin(all_coords), std::end(all_coords), compare_coords);
-		auto u = std::unique(std::begin(all_coords), std::end(all_coords),
-		                     check_coords);
-		bool containsDuplicate = u != std::end(all_coords);
-		REQUIRE(!containsDuplicate);
-	}
 
-	SECTION("histo3d-detector-pairs-uniqueness")
-	{
-		std::vector<det_pair_t> allDetPairs;
-
-		const size_t numBins = histo3d->count();
-		allDetPairs.resize(numBins);
-
-		for (bin_t binId = 0; binId < numBins; binId++)
-		{
-			det_pair_t currPair = histo3d->getDetectorPair(binId);
-			allDetPairs[binId] = currPair;
+			std::sort(std::begin(allDetPairs), std::end(allDetPairs),
+			          compare_det_pairs);
+			auto u = std::unique(std::begin(allDetPairs), std::end(allDetPairs),
+			                     check_det_pairs);
+			bool containsDuplicate = u != std::end(allDetPairs);
+			REQUIRE(!containsDuplicate);
 		}
 
-		std::sort(std::begin(allDetPairs), std::end(allDetPairs),
-		          compare_det_pairs);
-		auto u = std::unique(std::begin(allDetPairs), std::end(allDetPairs),
-		                     check_det_pairs);
-		bool containsDuplicate = u != std::end(allDetPairs);
-		REQUIRE(!containsDuplicate);
-	}
-
-	SECTION("histo3d-line-integrity")
-	{
-		auto someListMode = std::make_unique<ListModeLUTOwned>(*scanner);
-		double epsilon = 1e-5;
-		someListMode->allocate(3);
-		someListMode->setDetectorIdsOfEvent(0, 15, 105);
-		someListMode->setDetectorIdsOfEvent(1, 238, 75);
-		someListMode->setDetectorIdsOfEvent(2, 200, 110);
-		for (size_t lmEv = 0; lmEv < someListMode->count(); lmEv++)
+		SECTION("histo3d-bin-iterator-trial-" + std::to_string(trial + 1))
 		{
-			auto [d1, d2] = someListMode->getDetectorPair(lmEv);
-			Line3D lor = Util::getNativeLOR(*scanner, *someListMode, lmEv);
-			bin_t binId = histo3d->getBinIdFromDetPair(d1, d2);
-			Line3D histoLor = Util::getNativeLOR(*scanner, *histo3d, binId);
-
-			CHECK(((std::abs(histoLor.point1.x - lor.point1.x) < epsilon &&
-			        std::abs(histoLor.point1.y - lor.point1.y) < epsilon &&
-			        std::abs(histoLor.point1.z - lor.point1.z) < epsilon &&
-			        std::abs(histoLor.point2.x - lor.point2.x) < epsilon &&
-			        std::abs(histoLor.point2.y - lor.point2.y) < epsilon &&
-			        std::abs(histoLor.point2.z - lor.point2.z) < epsilon) ||
-			       (std::abs(histoLor.point1.x - lor.point2.x) < epsilon &&
-			        std::abs(histoLor.point1.y - lor.point2.y) < epsilon &&
-			        std::abs(histoLor.point1.z - lor.point2.z) < epsilon &&
-			        std::abs(histoLor.point2.x - lor.point1.x) < epsilon &&
-			        std::abs(histoLor.point2.y - lor.point1.y) < epsilon &&
-			        std::abs(histoLor.point2.z - lor.point1.z) < epsilon)));
-		}
-	}
-
-	SECTION("histo3d-bin-iterator")
-	{
-		size_t num_subsets = histo3d->numPhi;  // Have a subset for every angle
-		for (size_t subset = 0; subset < num_subsets; subset++)
-		{
-			auto binIter = histo3d->getBinIter(num_subsets, subset);
-			CHECK(binIter->size() == histo3d->count() / num_subsets);
-			CHECK(binIter->size() == histo3d->numR * histo3d->numZBin);
-			coord_t r0, phi0, z_bin0;
-			histo3d->getCoordsFromBinId(binIter->get(0), r0, phi0, z_bin0);
-			for (bin_t bin = 1; bin < binIter->size(); bin++)
+			size_t num_subsets =
+			    histo3d->numPhi;  // Have a subset for every angle
+			for (size_t subset = 0; subset < num_subsets; subset++)
 			{
-				coord_t r, phi, z_bin;
-				histo3d->getCoordsFromBinId(binIter->get(bin), r, phi, z_bin);
-				REQUIRE(phi == phi0);
+				auto binIter = histo3d->getBinIter(num_subsets, subset);
+				CHECK(binIter->size() == histo3d->count() / num_subsets);
+				CHECK(binIter->size() == histo3d->numR * histo3d->numZBin);
+				coord_t r0, phi0, z_bin0;
+				histo3d->getCoordsFromBinId(binIter->get(0), r0, phi0, z_bin0);
+				for (bin_t bin = 1; bin < binIter->size(); bin++)
+				{
+					coord_t r, phi, z_bin;
+					histo3d->getCoordsFromBinId(binIter->get(bin), r, phi,
+					                            z_bin);
+					REQUIRE(phi == phi0);
+				}
 			}
 		}
-	}
 
-	SECTION("histo3d-get-lor-id")
-	{
-		bin_t binId = 12;
-		auto [d1_ref, d2_ref] = histo3d->getDetectorPair(binId);
-		histo_bin_t lorId = histo3d->getHistogramBin(binId);
-		auto newBin = std::get<bin_t>(lorId);
-		det_pair_t detPair = histo3d->getDetectorPair(newBin);
-		CHECK(d1_ref == detPair.d1);
-		CHECK(d2_ref == detPair.d2);
+		SECTION("histo3d-get-lor-id-trial-" + std::to_string(trial + 1))
+		{
+			bin_t binId = 12;
+			auto [d1_ref, d2_ref] = histo3d->getDetectorPair(binId);
+			histo_bin_t lorId = histo3d->getHistogramBin(binId);
+			auto newBin = std::get<bin_t>(lorId);
+			det_pair_t detPair = histo3d->getDetectorPair(newBin);
+			CHECK(d1_ref == detPair.d1);
+			CHECK(d2_ref == detPair.d2);
+		}
+
+		SECTION("histo3d-allowed-lors-trial-" + std::to_string(trial + 1))
+		{
+			for (det_id_t d1 = 0; d1 < numDets; d1++)
+			{
+				for (det_id_t d2 = d1 + 1; d2 < numDets; d2++)
+				{
+					auto [doi_d1, ring_d1, posInRing_d1] =
+					    getDetectorPositionInScanner(*scanner, d1);
+					auto [doi_d2, ring_d2, posInRing_d2] =
+					    getDetectorPositionInScanner(*scanner, d2);
+
+					// Check ring difference
+					if (std::abs(ring_d1 - ring_d2) >
+					    static_cast<int64_t>(scanner->maxRingDiff))
+					{
+						continue;
+					}
+
+					// Check difference in ring (angle difference)
+					if (std::min(
+					        Util::positiveModulo(posInRing_d1 - posInRing_d2,
+					                             scanner->detsPerRing),
+					        Util::positiveModulo(posInRing_d2 - posInRing_d1,
+					                             scanner->detsPerRing)) <
+					    static_cast<int64_t>(scanner->minAngDiff))
+					{
+						continue;
+					}
+
+					coord_t r, phi, z_bin;
+					histo3d->getCoordsFromDetPair(d1, d2, r, phi, z_bin);
+
+					det_pair_t detPair2;
+					histo3d->getDetPairFromCoords(r, phi, z_bin, detPair2.d1,
+					                              detPair2.d2);
+
+					bool checkDetPair = d1 == detPair2.d1 && d2 == detPair2.d2;
+					bool checkDetPairSwapped =
+					    d1 == detPair2.d2 && d2 == detPair2.d1;
+					CHECK((checkDetPairSwapped || checkDetPair));
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
- Fix duplicate lines bug when minAngDiff is set to 1
- detsPerRing has to be even, so an assertion is added
- Add safety checks for maxRingDiff and minAngDiff
- Use the faster hash table class `parallel_hashmap` for Histogram3D (since it acts as a drop-in replacement)
- Elaborate unit test for Histogram3D