### PR TITLE
Parallel batch loading

### DIFF
--- a/doc/python/owned_vs_alias.md
+++ b/doc/python/owned_vs_alias.md
@@ -118,10 +118,10 @@ hisDev = yrt.ProjectionDataDeviceAlias(scanner, his, 1)
 
 # Important: This is needed to precompute all LORs
 # Arguments: Load events from the batch 0 of the subset 0
-hisDev.loadEventLORs(0, 0)
+hisDev.prepareBatchLORs(0, 0)
 
 # Create a torch array with the appropriate size
-onesProj = torch.ones([hisDev.getCurrentBatchSize()], device=cuda0,
+onesProj = torch.ones([hisDev.getLoadedBatchSize()], device=cuda0,
                       dtype=torch.float32, layout=torch.strided)
 
 # Bind PyTorch array to YRT-PET ProjectionData

--- a/yrt-pet/CMakeLists.txt
+++ b/yrt-pet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Jinsong Ouayang, 03-2019
+# Jinsong Ouyang, 03-2019
 
 cmake_minimum_required(VERSION 3.21)
 project(yrt-pet VERSION 0.0.1 LANGUAGES CXX)

--- a/yrt-pet/include/datastruct/image/ImageDevice.cuh
+++ b/yrt-pet/include/datastruct/image/ImageDevice.cuh
@@ -72,7 +72,7 @@ public:
 	ImageDeviceOwned(const ImageParams& imgParams, const std::string& filename,
 	                 const cudaStream_t* stream_ptr = nullptr);
 	~ImageDeviceOwned() override;
-	void allocate(bool synchronize = true);
+	void allocate(bool synchronize = true, bool initializeToZero = true);
 	void readFromFile(const ImageParams& params, const std::string& filename);
 	void readFromFile(const std::string& filename);
 	float* getDevicePointer() override;

--- a/yrt-pet/include/datastruct/image/ImageDevice.cuh
+++ b/yrt-pet/include/datastruct/image/ImageDevice.cuh
@@ -40,12 +40,19 @@ public:
 	                       float threshold) override;
 	void writeToFile(const std::string& image_fname) const override;
 
-	void copyFromHostImage(const Image* imSrc);
-	void copyFromDeviceImage(const ImageDevice* imSrc,
-	                         bool p_synchronize = true);
+	void copyFromHostImage(const Image* imSrc, bool synchronize);
+	void copyFromDeviceImage(const ImageDevice* imSrc, bool p_synchronize);
+
+	void setValueDevice(float initValue, bool synchronize);
+	void updateEMThresholdDevice(ImageDevice* updateImg,
+	                             const ImageDevice* normImg, float threshold,
+	                             bool synchronize);
+	void addFirstImageToSecondDevice(ImageDevice* imgOut,
+	                                 bool synchronize) const;
 	void applyThresholdDevice(const ImageDevice* maskImg, float threshold,
 	                          float val_le_scale, float val_le_off,
-	                          float val_gt_scale, float val_gt_off);
+	                          float val_gt_scale, float val_gt_off,
+	                          bool synchronize);
 
 protected:
 	explicit ImageDevice(const cudaStream_t* stream_ptr = nullptr);

--- a/yrt-pet/include/datastruct/projection/LORsDevice.cuh
+++ b/yrt-pet/include/datastruct/projection/LORsDevice.cuh
@@ -21,34 +21,23 @@ class LORsDevice
 public:
 	LORsDevice();
 
-	// Load the events' detector ids from a specific subset&batch id
-	// method kept for legacy reasons
-	void precomputeAndLoadBatchLORs(const BinIterator& binIter,
-	                                const GPUBatchSetup& batchSetup,
-	                                size_t subsetId, size_t batchId,
-	                                const ProjectionData& reference,
-	                                const cudaStream_t* stream = nullptr);
-
 	void precomputeBatchLORs(const BinIterator& binIter,
-	                         const GPUBatchSetup& batchSetup, size_t subsetId,
-	                         size_t batchId, const ProjectionData& reference);
+	                         const GPUBatchSetup& batchSetup, int subsetId,
+	                         int batchId, const ProjectionData& reference);
 	void loadPrecomputedLORsToDevice(GPULaunchConfig launchConfig);
-
-	std::shared_ptr<ScannerDevice> getScannerDevice() const;
-	const Scanner& getScanner() const;
 
 	// Gets the size of the last precomputed batch
 	size_t getPrecomputedBatchSize() const;
 	// Gets the index of the last precomputed batch
-	size_t getPrecomputedBatchId() const;
+	int getPrecomputedBatchId() const;
 	// Get the index of the last precomputed subset
-	size_t getPrecomputedSubsetId() const;
+	int getPrecomputedSubsetId() const;
 	// Gets the size of the last-loaded batch
 	size_t getLoadedBatchSize() const;
 	// Gets the index of the last-loaded batch
-	size_t getLoadedBatchId() const;
+	int getLoadedBatchId() const;
 	// Gets the index of the last-loaded subset
-	size_t getLoadedSubsetId() const;
+	int getLoadedSubsetId() const;
 
 	const float4* getLorDet1PosDevicePointer() const;
 	const float4* getLorDet1OrientDevicePointer() const;
@@ -83,10 +72,10 @@ private:
 	PageLockedBuffer<float> m_tempLorTOFValue;
 	bool m_hasTOF;
 	size_t m_precomputedBatchSize;
-	size_t m_precomputedBatchId;
-	size_t m_precomputedSubsetId;
+	int m_precomputedBatchId;
+	int m_precomputedSubsetId;
 	bool m_areLORsPrecomputed;
 	size_t m_loadedBatchSize;
-	size_t m_loadedBatchId;
-	size_t m_loadedSubsetId;
+	int m_loadedBatchId;
+	int m_loadedSubsetId;
 };

--- a/yrt-pet/include/datastruct/projection/ProjectionDataDevice.cuh
+++ b/yrt-pet/include/datastruct/projection/ProjectionDataDevice.cuh
@@ -49,9 +49,9 @@ public:
 
 	// Load the events' detector ids from a specific subset&batch id and prepare
 	// the projection values buffer
-	void prepareBatchLORs(size_t subsetId, size_t batchId,
+	void prepareBatchLORs(int subsetId, int batchId,
 	                      GPULaunchConfig launchConfig);
-	void precomputeBatchLORs(size_t subsetId, size_t batchId);
+	void precomputeBatchLORs(int subsetId, int batchId);
 	void loadPrecomputedLORsToDevice(GPULaunchConfig launchConfig);
 
 	void loadProjValuesFromReference(GPULaunchConfig launchConfig);

--- a/yrt-pet/include/datastruct/scanner/ScannerDevice.cuh
+++ b/yrt-pet/include/datastruct/scanner/ScannerDevice.cuh
@@ -16,9 +16,9 @@ class ScannerDevice
 public:
 	// Loads the scanner into the device
 	explicit ScannerDevice(const Scanner& pr_scanner,
-	                         const cudaStream_t* pp_stream = nullptr);
-	void allocate(const cudaStream_t* stream = nullptr);
-	void load(const cudaStream_t* stream = nullptr);
+	                       const cudaStream_t* pp_stream = nullptr);
+	void allocate(GPULaunchConfig p_launchConfig);
+	void load(GPULaunchConfig p_launchConfig);
 	const float4* getDetPosDevicePointer() const;
 	const float4* getDetOrientDevicePointer() const;
 	const Scanner& getScanner() const;

--- a/yrt-pet/include/operators/DeviceSynchronized.cuh
+++ b/yrt-pet/include/operators/DeviceSynchronized.cuh
@@ -8,6 +8,7 @@
 #include "datastruct/image/ImageBase.hpp"
 #include "datastruct/scanner/Scanner.hpp"
 #include "recon/CUParameters.hpp"
+#include "utils/GPUStream.cuh"
 #include "utils/GPUTypes.cuh"
 
 #include <cuda_runtime_api.h>
@@ -40,4 +41,8 @@ protected:
 
 	const cudaStream_t* mp_mainStream;
 	const cudaStream_t* mp_auxStream;
+
+	// In case the streams were not specified
+	std::unique_ptr<GPUStream> mp_mainStreamPtr;
+	std::unique_ptr<GPUStream> mp_auxStreamPtr;
 };

--- a/yrt-pet/include/operators/DeviceSynchronized.cuh
+++ b/yrt-pet/include/operators/DeviceSynchronized.cuh
@@ -23,6 +23,8 @@ namespace Util
 	GPULaunchParams initiateDeviceParameters(size_t batchSize);
 }  // namespace Util
 
+// This class is there to represent operators that will always use the same
+//  stream(s)
 class DeviceSynchronized
 {
 public:
@@ -33,12 +35,9 @@ public:
 	static CUImageParams getCUImageParams(const ImageParams& imgParams);
 
 protected:
-	explicit DeviceSynchronized(bool p_synchronized = true,
-							const cudaStream_t* pp_mainStream = nullptr,
-							const cudaStream_t* pp_auxStream = nullptr);
+	explicit DeviceSynchronized(const cudaStream_t* pp_mainStream = nullptr,
+	                            const cudaStream_t* pp_auxStream = nullptr);
 
-	bool m_synchronized;
 	const cudaStream_t* mp_mainStream;
 	const cudaStream_t* mp_auxStream;
 };
-

--- a/yrt-pet/include/operators/OperatorProjectorDD_GPU.cuh
+++ b/yrt-pet/include/operators/OperatorProjectorDD_GPU.cuh
@@ -15,19 +15,19 @@ class OperatorProjectorDD_GPU : public OperatorProjectorDevice
 {
 public:
 	explicit OperatorProjectorDD_GPU(const OperatorProjectorParams& projParams,
-	                                 bool p_synchronized = true,
 	                                 const cudaStream_t* mainStream = nullptr,
 	                                 const cudaStream_t* auxStream = nullptr);
 
 protected:
-	void applyAOnLoadedBatch(ImageDevice& img,
-	                         ProjectionDataDevice& dat) override;
-	void applyAHOnLoadedBatch(ProjectionDataDevice& dat,
-	                          ImageDevice& img) override;
+	void applyAOnLoadedBatch(ImageDevice& img, ProjectionDataDevice& dat,
+	                         bool synchronize) override;
+	void applyAHOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img,
+	                          bool synchronize) override;
 
 private:
 	template <bool IsForward>
-	void applyOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img);
+	void applyOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img,
+	                        bool synchronize);
 
 	template <bool IsForward, bool HasTOF, bool HasProjPsf>
 	static void launchKernel(

--- a/yrt-pet/include/operators/OperatorProjectorDevice.cuh
+++ b/yrt-pet/include/operators/OperatorProjectorDevice.cuh
@@ -26,7 +26,6 @@ public:
 
 	unsigned int getGridSize() const;
 	unsigned int getBlockSize() const;
-	bool isSynchronized() const;
 
 	bool requiresIntermediaryProjData() const;
 	void setupTOFHelper(float tofWidth_ps, int tofNumStd = -1);
@@ -34,16 +33,20 @@ public:
 	void applyA(const Variable* in, Variable* out) override;
 	void applyAH(const Variable* in, Variable* out) override;
 
-protected:
-	virtual void applyAOnLoadedBatch(ImageDevice& img,
-	                                 ProjectionDataDevice& dat) = 0;
-	virtual void applyAHOnLoadedBatch(ProjectionDataDevice& dat,
-	                                  ImageDevice& img) = 0;
+	void applyA(const Variable* in, Variable* out, bool synchronize);
+	void applyAH(const Variable* in, Variable* out, bool synchronize);
 
+protected:
 	explicit OperatorProjectorDevice(
 	    const OperatorProjectorParams& pr_projParams,
-	    bool p_synchronized = true, const cudaStream_t* pp_mainStream = nullptr,
+	    const cudaStream_t* pp_mainStream = nullptr,
 	    const cudaStream_t* pp_auxStream = nullptr);
+
+	virtual void applyAOnLoadedBatch(ImageDevice& img,
+	                                 ProjectionDataDevice& dat,
+	                                 bool synchronize) = 0;
+	virtual void applyAHOnLoadedBatch(ProjectionDataDevice& dat,
+	                                  ImageDevice& img, bool synchronize) = 0;
 
 	void setBatchSize(size_t newBatchSize);
 

--- a/yrt-pet/include/operators/OperatorProjectorDevice.cuh
+++ b/yrt-pet/include/operators/OperatorProjectorDevice.cuh
@@ -42,6 +42,7 @@ protected:
 	    const cudaStream_t* pp_mainStream = nullptr,
 	    const cudaStream_t* pp_auxStream = nullptr);
 
+	// These must run on the main stream
 	virtual void applyAOnLoadedBatch(ImageDevice& img,
 	                                 ProjectionDataDevice& dat,
 	                                 bool synchronize) = 0;

--- a/yrt-pet/include/operators/OperatorProjectorSiddon_GPU.cuh
+++ b/yrt-pet/include/operators/OperatorProjectorSiddon_GPU.cuh
@@ -15,19 +15,20 @@ class OperatorProjectorSiddon_GPU : public OperatorProjectorDevice
 {
 public:
 	explicit OperatorProjectorSiddon_GPU(
-	    const OperatorProjectorParams& projParams, bool p_synchronized = true,
+	    const OperatorProjectorParams& projParams,
 	    const cudaStream_t* mainStream = nullptr,
 	    const cudaStream_t* auxStream = nullptr);
 
 protected:
-	void applyAOnLoadedBatch(ImageDevice& img,
-	                         ProjectionDataDevice& dat) override;
-	void applyAHOnLoadedBatch(ProjectionDataDevice& dat,
-	                          ImageDevice& img) override;
+	void applyAOnLoadedBatch(ImageDevice& img, ProjectionDataDevice& dat,
+	                         bool synchronize) override;
+	void applyAHOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img,
+	                          bool synchronize) override;
 
 private:
 	template <bool IsForward>
-	void applyOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img);
+	void applyOnLoadedBatch(ProjectionDataDevice& dat, ImageDevice& img,
+				 bool synchronize);
 
 	template <bool IsForward, bool HasTOF>
 	void launchKernel(

--- a/yrt-pet/include/operators/ProjectionPsfManagerDevice.cuh
+++ b/yrt-pet/include/operators/ProjectionPsfManagerDevice.cuh
@@ -23,12 +23,12 @@ struct ProjectionPsfProperties
 class ProjectionPsfManagerDevice : public ProjectionPsfManager
 {
 public:
-	explicit
-	    ProjectionPsfManagerDevice(const std::string& psfFilename,
-	                               const cudaStream_t* pp_stream = nullptr);
+	explicit ProjectionPsfManagerDevice(
+	    const std::string& psfFilename,
+	    const cudaStream_t* pp_stream = nullptr);
 	void readFromFile(const std::string& psfFilename) override;
 	void readFromFile(const std::string& psfFilename,
-	                  const cudaStream_t* pp_stream);
+	                  GPULaunchConfig launchConfig);
 	const float* getKernelsDevicePointer() const;
 	const float* getFlippedKernelsDevicePointer() const;
 
@@ -39,8 +39,7 @@ protected:
 	std::unique_ptr<DeviceArray<float>> mpd_kernelsFlipped;
 
 private:
-	void copyKernelsToDevice(const cudaStream_t* pp_stream = nullptr);
+	void copyKernelsToDevice(GPULaunchConfig launchConfig);
 	void readFromFileInternal(const std::string& psfFilename,
-	                          const cudaStream_t* pp_stream = nullptr);
+	                          GPULaunchConfig launchConfig);
 };
-

--- a/yrt-pet/include/recon/Corrector_GPU.cuh
+++ b/yrt-pet/include/recon/Corrector_GPU.cuh
@@ -34,28 +34,31 @@ public:
 	    const ProjectionData& measurements) override;
 
 	void loadAdditiveCorrectionFactorsToTemporaryDeviceBuffer(
-	    const cudaStream_t* stream = nullptr);
+	    GPULaunchConfig launchConfig);
 	void loadInVivoAttenuationFactorsToTemporaryDeviceBuffer(
-	    const cudaStream_t* stream = nullptr);
+	    GPULaunchConfig launchConfig);
 
 	// Getters
 	const ProjectionDataDevice* getTemporaryDeviceBuffer() const;
 	ProjectionDataDevice* getTemporaryDeviceBuffer();
 
-	// Use ACF histogram for sensitivity image generation
+	// Use ACF histogram to apply hardware attenuation correction in the
+	//  sensitivity image
 	void applyHardwareAttenuationToGivenDeviceBufferFromACFHistogram(
-	    ProjectionDataDevice* destProjData, const cudaStream_t* stream);
-	// The projector used is in case the attenuation image needs to be projected
+	    ProjectionDataDevice* destProjData, GPULaunchConfig launchConfig);
+
+	// Use attenuation image to apply hardware attenuation correction in the
+	//  sensitivity image
 	void applyHardwareAttenuationToGivenDeviceBufferFromAttenuationImage(
 	    ProjectionDataDevice* destProjData, OperatorProjectorDevice* projector,
-	    const cudaStream_t* stream = nullptr);
+	    GPULaunchConfig launchConfig);
 
 private:
 	// Helper function
 	void loadPrecomputedCorrectionFactorsToTemporaryDeviceBuffer(
-	    const ProjectionList* factors, const cudaStream_t* stream = nullptr);
-	void initializeTemporaryDeviceImageIfNeeded(
-	    const Image* hostReference, const cudaStream_t* stream = nullptr);
+	    const ProjectionList* factors, GPULaunchConfig launchConfig);
+	void initializeTemporaryDeviceImageIfNeeded(const Image* hostReference,
+	                                            GPULaunchConfig launchConfig);
 
 	// Internal management
 	void initializeTemporaryDeviceImageIfNeeded(const Image* hostReference);

--- a/yrt-pet/include/recon/OSEM.hpp
+++ b/yrt-pet/include/recon/OSEM.hpp
@@ -149,7 +149,6 @@ protected:
 	virtual Corrector& getCorrector() = 0;
 
 	// Common methods
-	virtual void loadBatch(int p_batchId, bool p_forRecon) = 0;
 	virtual void loadSubset(int p_subsetId, bool p_forRecon) = 0;
 
 private:

--- a/yrt-pet/include/recon/OSEM_CPU.hpp
+++ b/yrt-pet/include/recon/OSEM_CPU.hpp
@@ -50,7 +50,6 @@ protected:
 	ProjectionData* getMLEMDataTmpBuffer() override;
 
 	// Common methods
-	void loadBatch(int batchId, bool forRecon) override;
 	void loadSubset(int subsetId, bool forRecon) override;
 	void computeEMUpdateImage(const ImageBase& inputImage,
 	                          ImageBase& destImage) override;

--- a/yrt-pet/include/recon/OSEM_GPU.cuh
+++ b/yrt-pet/include/recon/OSEM_GPU.cuh
@@ -85,6 +85,5 @@ private:
 	int m_current_OSEM_subset;
 
 	GPUStream m_mainStream;
-	// TODO: Add parallel batch loading
-	// GPUStream m_auxStream;
+	GPUStream m_auxStream;
 };

--- a/yrt-pet/include/recon/OSEM_GPU.cuh
+++ b/yrt-pet/include/recon/OSEM_GPU.cuh
@@ -63,7 +63,6 @@ public:
 	ProjectionDataDeviceOwned* getMLEMDataTmpDeviceBuffer();
 
 	// Common methods
-	void loadBatch(int batchId, bool forRecon) override;
 	void loadSubset(int subsetId, bool forRecon) override;
 	void addImagePSF(const std::string& p_imagePsf_fname) override;
 

--- a/yrt-pet/include/utils/DeviceArray.cuh
+++ b/yrt-pet/include/utils/DeviceArray.cuh
@@ -19,22 +19,22 @@ public:
 		m_size = 0;
 		if (p_size > 0)
 		{
-			allocate(p_size, stream, true);
+			// Constructors should be synchronous
+			allocate(p_size, {stream, true});
 		}
 	}
 
-	~DeviceArray() { Deallocate(); }
+	~DeviceArray() { Deallocate({nullptr, true}); }
 
-	bool allocate(size_t p_size, const cudaStream_t* stream = nullptr,
-	              bool synchronize = true)
+	bool allocate(size_t p_size, GPULaunchConfig p_launchConfig)
 	{
 		if (p_size > m_size)
 		{
 			if (m_size > 0)
 			{
-				Deallocate(stream);
+				Deallocate(p_launchConfig);
 			}
-			Util::allocateDevice(&mpd_data, p_size, stream, synchronize);
+			Util::allocateDevice(&mpd_data, p_size, p_launchConfig);
 			m_size = p_size;
 			return true;
 		}
@@ -42,33 +42,27 @@ public:
 	}
 
 	void copyFromHost(const T* source, size_t numElements,
-	                  const cudaStream_t* stream = nullptr,
-	                  bool synchronize = true)
+	                  GPULaunchConfig p_launchConfig)
 	{
-		Util::copyHostToDevice(mpd_data, source, numElements, stream,
-		                       synchronize);
+		Util::copyHostToDevice(mpd_data, source, numElements, p_launchConfig);
 	}
 
 	void copyToHost(T* dest, size_t numElements,
-	                const cudaStream_t* stream = nullptr,
-	                bool synchronize = true)
+	                GPULaunchConfig p_launchConfig)
 	{
-		Util::copyDeviceToHost(dest, mpd_data, numElements, stream,
-		                       synchronize);
+		Util::copyDeviceToHost(dest, mpd_data, numElements, p_launchConfig);
 	}
 
-	void memset(int value, const cudaStream_t* stream = nullptr,
-	            bool synchronize = true)
+	void memset(int value, GPULaunchConfig p_launchConfig)
 	{
-		Util::memsetDevice(mpd_data, value, m_size, stream, synchronize);
+		Util::memsetDevice(mpd_data, value, m_size, p_launchConfig);
 	}
 
-	void Deallocate(const cudaStream_t* stream = nullptr,
-	                bool synchronize = true)
+	void Deallocate(GPULaunchConfig p_launchConfig)
 	{
 		if (m_size > 0)
 		{
-			Util::deallocateDevice(mpd_data, stream, synchronize);
+			Util::deallocateDevice(mpd_data, p_launchConfig);
 			mpd_data = nullptr;
 			m_size = 0;
 		}

--- a/yrt-pet/include/utils/GPUMemory.cuh
+++ b/yrt-pet/include/utils/GPUMemory.cuh
@@ -3,26 +3,27 @@
 
 #include "utils/Assert.hpp"
 #include "utils/GPUUtils.cuh"
+#include "utils/GPUTypes.cuh"
 
 namespace Util
 {
 	template <typename T>
 	void allocateDevice(T** ppd_data, size_t p_numElems,
-	                    const cudaStream_t* pp_stream = nullptr,
-	                    bool p_synchronize = true)
+	                    GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
-			cudaMallocAsync(ppd_data, sizeof(T) * p_numElems, *pp_stream);
-			if (p_synchronize)
+			cudaMallocAsync(ppd_data, sizeof(T) * p_numElems,
+			                *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaMalloc(ppd_data, sizeof(T) * p_numElems);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}
@@ -31,21 +32,20 @@ namespace Util
 	}
 
 	template <typename T>
-	void deallocateDevice(T* ppd_data, const cudaStream_t* pp_stream = nullptr,
-	                      bool p_synchronize = true)
+	void deallocateDevice(T* ppd_data, GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
-			cudaFreeAsync(ppd_data, *pp_stream);
-			if (p_synchronize)
+			cudaFreeAsync(ppd_data, *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaFree(ppd_data);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}
@@ -55,23 +55,22 @@ namespace Util
 
 	template <typename T>
 	void copyHostToDevice(T* ppd_dest, const T* pph_src, size_t p_numElems,
-	                      const cudaStream_t* pp_stream = nullptr,
-	                      bool p_synchronize = true)
+	                      GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
 			cudaMemcpyAsync(ppd_dest, pph_src, p_numElems * sizeof(T),
-			                cudaMemcpyHostToDevice, *pp_stream);
-			if (p_synchronize)
+			                cudaMemcpyHostToDevice, *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaMemcpy(ppd_dest, pph_src, p_numElems * sizeof(T),
 			           cudaMemcpyHostToDevice);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}
@@ -81,23 +80,22 @@ namespace Util
 
 	template <typename T>
 	void copyDeviceToHost(T* pph_dest, const T* ppd_src, size_t p_numElems,
-	                      const cudaStream_t* pp_stream = nullptr,
-	                      bool p_synchronize = true)
+	                      GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
 			cudaMemcpyAsync(pph_dest, ppd_src, p_numElems * sizeof(T),
-			                cudaMemcpyDeviceToHost, *pp_stream);
-			if (p_synchronize)
+			                cudaMemcpyDeviceToHost, *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaMemcpy(pph_dest, ppd_src, p_numElems * sizeof(T),
 			           cudaMemcpyDeviceToHost);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}
@@ -107,23 +105,22 @@ namespace Util
 
 	template <typename T>
 	void copyDeviceToDevice(T* ppd_dest, const T* ppd_src, size_t p_numElems,
-	                        const cudaStream_t* pp_stream = nullptr,
-	                        bool p_synchronize = true)
+	                        GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
 			cudaMemcpyAsync(ppd_dest, ppd_src, p_numElems * sizeof(T),
-			                cudaMemcpyDeviceToDevice, *pp_stream);
-			if (p_synchronize)
+			                cudaMemcpyDeviceToDevice, *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaMemcpy(ppd_dest, ppd_src, p_numElems * sizeof(T),
 			           cudaMemcpyDeviceToDevice);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}
@@ -133,22 +130,21 @@ namespace Util
 
 	template <typename T>
 	void memsetDevice(T* ppd_data, int value, size_t p_numElems,
-	                  const cudaStream_t* pp_stream = nullptr,
-	                  bool p_synchronize = true)
+	                  GPULaunchConfig p_launchConfig)
 	{
-		if (pp_stream != nullptr)
+		if (p_launchConfig.stream != nullptr)
 		{
 			cudaMemsetAsync(ppd_data, value, sizeof(T) * p_numElems,
-			                *pp_stream);
-			if (p_synchronize)
+			                *p_launchConfig.stream);
+			if (p_launchConfig.synchronize)
 			{
-				cudaStreamSynchronize(*pp_stream);
+				cudaStreamSynchronize(*p_launchConfig.stream);
 			}
 		}
 		else
 		{
 			cudaMemset(ppd_data, value, sizeof(T) * p_numElems);
-			if (p_synchronize)
+			if (p_launchConfig.synchronize)
 			{
 				cudaDeviceSynchronize();
 			}

--- a/yrt-pet/include/utils/GPUTypes.cuh
+++ b/yrt-pet/include/utils/GPUTypes.cuh
@@ -33,20 +33,21 @@ public:
 			lastBatchSize = batchSize;
 		}
 	}
-	[[nodiscard]] size_t getBatchSize(size_t batchId) const
+	[[nodiscard]] size_t getBatchSize(int batchId) const
 	{
+		ASSERT(batchId < numBatches);
 		if (batchId == numBatches - 1)
 		{
 			return lastBatchSize;
 		}
 		return batchSize;
 	}
-	[[nodiscard]] size_t getNumBatches() const { return numBatches; }
+	[[nodiscard]] int getNumBatches() const { return numBatches; }
 
 private:
 	size_t batchSize;
 	size_t lastBatchSize;
-	size_t numBatches;
+	int numBatches;
 };
 
 // Structure encoding how a kernel should be called

--- a/yrt-pet/include/utils/GPUTypes.cuh
+++ b/yrt-pet/include/utils/GPUTypes.cuh
@@ -7,6 +7,7 @@
 
 #include "Assert.hpp"
 
+#include <driver_types.h>
 #include <vector_types.h>
 
 class GPUBatchSetup
@@ -46,6 +47,15 @@ private:
 	size_t batchSize;
 	size_t lastBatchSize;
 	size_t numBatches;
+};
+
+// Structure encoding how a kernel should be called
+struct GPULaunchConfig
+{
+	// Which stream to run
+	const cudaStream_t* stream = nullptr;
+	// Whether to synchronize after the operation or not
+	bool synchronize = true;
 };
 
 struct GPULaunchParams

--- a/yrt-pet/src/datastruct/projection/LORsDevice.cu
+++ b/yrt-pet/src/datastruct/projection/LORsDevice.cu
@@ -16,27 +16,19 @@
 LORsDevice::LORsDevice()
     : m_hasTOF(false),
       m_precomputedBatchSize(0ull),
-      m_precomputedBatchId(0ull),
-      m_precomputedSubsetId(0ull),
+      m_precomputedBatchId(-1),
+      m_precomputedSubsetId(-1),
       m_areLORsPrecomputed(false),
       m_loadedBatchSize(0ull),
-      m_loadedBatchId(0ull),
-      m_loadedSubsetId(0ull)
+      m_loadedBatchId(-1),
+      m_loadedSubsetId(-1)
 {
 	initializeDeviceArrays();
 }
 
-void LORsDevice::precomputeAndLoadBatchLORs(const BinIterator& binIter,
-                                            const GPUBatchSetup& batchSetup,
-                                            size_t subsetId, size_t batchId,
-                                            const ProjectionData& reference,
-                                            const cudaStream_t* stream)
-{
-}
-
 void LORsDevice::precomputeBatchLORs(const BinIterator& binIter,
                                      const GPUBatchSetup& batchSetup,
-                                     size_t subsetId, size_t batchId,
+                                     int subsetId, int batchId,
                                      const ProjectionData& reference)
 {
 	if (m_precomputedSubsetId != subsetId || m_precomputedBatchId != batchId ||
@@ -148,12 +140,12 @@ size_t LORsDevice::getPrecomputedBatchSize() const
 	return m_precomputedBatchSize;
 }
 
-size_t LORsDevice::getPrecomputedBatchId() const
+int LORsDevice::getPrecomputedBatchId() const
 {
 	return m_precomputedBatchId;
 }
 
-size_t LORsDevice::getPrecomputedSubsetId() const
+int LORsDevice::getPrecomputedSubsetId() const
 {
 	return m_precomputedSubsetId;
 }
@@ -254,12 +246,12 @@ size_t LORsDevice::getLoadedBatchSize() const
 	return m_loadedBatchSize;
 }
 
-size_t LORsDevice::getLoadedBatchId() const
+int LORsDevice::getLoadedBatchId() const
 {
 	return m_loadedBatchId;
 }
 
-size_t LORsDevice::getLoadedSubsetId() const
+int LORsDevice::getLoadedSubsetId() const
 {
 	return m_loadedSubsetId;
 }

--- a/yrt-pet/src/datastruct/projection/LORsDevice.cu
+++ b/yrt-pet/src/datastruct/projection/LORsDevice.cu
@@ -101,7 +101,6 @@ void LORsDevice::precomputeBatchLORs(const BinIterator& binIter,
 void LORsDevice::loadPrecomputedLORsToDevice(GPULaunchConfig launchConfig)
 {
 	const cudaStream_t* stream = launchConfig.stream;
-	ASSERT(stream != nullptr);
 
 	if (m_loadedSubsetId != m_precomputedSubsetId ||
 	    m_loadedBatchId != m_precomputedBatchId)
@@ -126,7 +125,14 @@ void LORsDevice::loadPrecomputedLORsToDevice(GPULaunchConfig launchConfig)
 		// In case the LOR loading is done for other reasons than projections
 		if (launchConfig.synchronize == true)
 		{
-			cudaStreamSynchronize(*stream);
+			if (stream != nullptr)
+			{
+				cudaStreamSynchronize(*stream);
+			}
+			else
+			{
+				cudaDeviceSynchronize();
+			}
 		}
 
 		m_loadedBatchSize = m_precomputedBatchSize;
@@ -179,10 +185,17 @@ void LORsDevice::allocateForPrecomputedLORsIfNeeded(
 		                                         {launchConfig.stream, false});
 	}
 
-	if (hasAllocated && launchConfig.stream != nullptr &&
+	if (hasAllocated &&
 	    launchConfig.synchronize)
 	{
-		cudaStreamSynchronize(*launchConfig.stream);
+		if ( launchConfig.stream != nullptr)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
+		else
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 }
 

--- a/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
+++ b/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
@@ -240,8 +240,7 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
 	{
 		// No need to "getProjectionValue" everywhere, just fill the buffer with
 		// the same value
-		clearProjectionsDevice(getReference()->getProjectionValue(0),
-		                       launchConfig);
+		clearProjectionsDevice(src->getProjectionValue(0), launchConfig);
 	}
 	else
 	{

--- a/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
+++ b/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
@@ -410,7 +410,7 @@ void ProjectionDataDevice::clearProjectionsDevice(float value,
 		clearProjectionsDevice(launchConfig);
 		return;
 	}
-	const size_t batchSize = getLoadedBatchSize();
+	const size_t batchSize = getPrecomputedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
 	ASSERT(getProjValuesDevicePointer() != nullptr);

--- a/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
+++ b/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
@@ -245,7 +245,7 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
 	}
 	else
 	{
-		const size_t batchSize = getLoadedBatchSize();
+		const size_t batchSize = getPrecomputedBatchSize();
 		ASSERT_MSG(batchSize > 0,
 		           "The Batch size is 0. You didn't load the LORs "
 		           "before loading the projection values");
@@ -253,10 +253,10 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
 		m_tempBuffer.reAllocateIfNeeded(batchSize);
 		float* projValuesBuffer = m_tempBuffer.getPointer();
 
-		auto* binIter = mp_binIteratorList.at(getLoadedSubsetId());
+		auto* binIter = mp_binIteratorList.at(getPrecomputedSubsetId());
 		const size_t firstBatchSize =
-		    getBatchSetup(getLoadedSubsetId()).getBatchSize(0);
-		const size_t offset = getLoadedBatchId() * firstBatchSize;
+		    getBatchSetup(getPrecomputedSubsetId()).getBatchSize(0);
+		const size_t offset = getPrecomputedBatchId() * firstBatchSize;
 
 		size_t binIdx;
 		bin_t binId;
@@ -406,6 +406,8 @@ void ProjectionDataDevice::clearProjectionsDevice(float value,
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
+	ASSERT(getProjValuesDevicePointer() != nullptr);
+
 	if (launchConfig.stream != nullptr)
 	{
 		clearProjections_kernel<<<launchParams.gridSize, launchParams.blockSize,
@@ -431,6 +433,8 @@ void ProjectionDataDevice::clearProjectionsDevice(float value,
 
 void ProjectionDataDevice::clearProjectionsDevice(GPULaunchConfig launchConfig)
 {
+	ASSERT(getProjValuesDevicePointer() != nullptr);
+
 	if (launchConfig.stream != nullptr)
 	{
 		cudaMemsetAsync(getProjValuesDevicePointer(), 0,
@@ -468,6 +472,9 @@ void ProjectionDataDevice::divideMeasurementsDevice(
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
+	ASSERT(getProjValuesDevicePointer() != nullptr);
+	ASSERT(measurements_device->getProjValuesDevicePointer() != nullptr);
+
 	if (launchConfig.stream != nullptr)
 	{
 		divideMeasurements_kernel<<<launchParams.gridSize,
@@ -498,6 +505,8 @@ void ProjectionDataDevice::invertProjValuesDevice(GPULaunchConfig launchConfig)
 {
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
+
+	ASSERT(getProjValuesDevicePointer() != nullptr);
 
 	if (launchConfig.stream != nullptr)
 	{
@@ -530,6 +539,9 @@ void ProjectionDataDevice::addProjValues(const ProjectionDataDevice* projValues,
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
+	ASSERT(projValues->getProjValuesDevicePointer() != nullptr);
+	ASSERT(getProjValuesDevicePointer() != nullptr);
+
 	if (launchConfig.stream != nullptr)
 	{
 		addProjValues_kernel<<<launchParams.gridSize, launchParams.blockSize, 0,
@@ -558,6 +570,8 @@ void ProjectionDataDevice::convertToACFsDevice(GPULaunchConfig launchConfig)
 {
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
+
+	ASSERT(getProjValuesDevicePointer() != nullptr);
 
 	if (launchConfig.stream != nullptr)
 	{
@@ -588,6 +602,8 @@ void ProjectionDataDevice::multiplyProjValues(
 {
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
+
+	ASSERT(getProjValuesDevicePointer() != nullptr);
 
 	if (launchConfig.stream != nullptr)
 	{
@@ -620,6 +636,8 @@ void ProjectionDataDevice::multiplyProjValues(float scalar,
 {
 	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
+
+	ASSERT(getProjValuesDevicePointer() != nullptr);
 
 	if (launchConfig.stream != nullptr)
 	{

--- a/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
+++ b/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
@@ -26,25 +26,25 @@ void py_setup_projectiondatadevice(py::module& m)
 	auto c = py::class_<ProjectionDataDevice, ProjectionList>(
 	    m, "ProjectionDataDevice");
 	c.def(
-	    "loadEventLORs",
+	    "prepareBatchLORs",
 	    [](ProjectionDataDevice& self, size_t subsetId, size_t batchId)
-	    { self.loadEventLORs(subsetId, batchId); },
+	    { self.prepareBatchLORs(subsetId, batchId, {nullptr, true}); },
 	    "Load the LORs of a specific batch in a specific subset", "subsetId"_a,
 	    "batchId"_a);
 	c.def("transferProjValuesToHost",
-	      [](ProjectionDataDevice& self, ProjectionData* dest)
+	      [](const ProjectionDataDevice& self, ProjectionData* dest)
 	      { self.transferProjValuesToHost(dest); });
 	c.def("loadProjValuesFromHost",
 	      [](ProjectionDataDevice& self, const ProjectionData* src)
-	      { self.loadProjValuesFromHost(src, nullptr); });
+	      { self.loadProjValuesFromHost(src, {nullptr, true}); });
 	c.def("loadProjValuesFromHost",
 	      [](ProjectionDataDevice& self, const Histogram* histo)
-	      { self.loadProjValuesFromHostHistogram(histo, nullptr); });
+	      { self.loadProjValuesFromHostHistogram(histo, {nullptr, true}); });
 	c.def("loadProjValuesFromReference", [](ProjectionDataDeviceOwned& self)
-	      { self.loadProjValuesFromReference(); });
-	c.def("getCurrentBatchSize", &ProjectionDataDevice::getCurrentBatchSize);
-	c.def("getCurrentBatchId", &ProjectionDataDevice::getCurrentBatchId);
-	c.def("getCurrentSubsetId", &ProjectionDataDevice::getCurrentSubsetId);
+	      { self.loadProjValuesFromReference({nullptr, true}); });
+	c.def("getLoadedBatchSize", &ProjectionDataDevice::getLoadedBatchSize);
+	c.def("getLoadedBatchId", &ProjectionDataDevice::getLoadedBatchId);
+	c.def("getLoadedSubsetId", &ProjectionDataDevice::getLoadedSubsetId);
 	c.def("getNumBatches", &ProjectionDataDevice::getNumBatches);
 	c.def("areLORsGathered", &ProjectionDataDevice::areLORsGathered);
 
@@ -61,7 +61,7 @@ void py_setup_projectiondatadevice(py::module& m)
 	            "share the LORs",
 	            "orig"_a);
 	c_owned.def("allocateForProjValues", [](ProjectionDataDeviceOwned& self)
-	            { self.allocateForProjValues(); });
+	            { self.allocateForProjValues({nullptr, true}); });
 
 	auto c_alias = py::class_<ProjectionDataDeviceAlias, ProjectionDataDevice>(
 	    m, "ProjectionDataDeviceAlias");
@@ -112,7 +112,7 @@ ProjectionDataDevice::ProjectionDataDevice(
       mp_binIteratorList(std::move(pp_binIteratorList)),
       mr_scanner(pr_scanner)
 {
-	mp_LORs = std::make_unique<LORsDevice>(mr_scanner);
+	mp_LORs = std::make_unique<LORsDevice>();
 	createBatchSetups(shareOfMemoryToUse);
 }
 
@@ -140,17 +140,6 @@ ProjectionDataDevice::ProjectionDataDevice(std::shared_ptr<LORsDevice> pp_LORs,
 	createBatchSetups(shareOfMemoryToUse);
 }
 
-ProjectionDataDevice::ProjectionDataDevice(
-    std::shared_ptr<ScannerDevice> pp_scannerDevice,
-    const ProjectionData* pp_reference, int num_OSEM_subsets,
-    float shareOfMemoryToUse)
-    : ProjectionList(pp_reference), mr_scanner(pp_scannerDevice->getScanner())
-{
-	createBinIterators(num_OSEM_subsets);
-	createBatchSetups(shareOfMemoryToUse);
-	mp_LORs = std::make_unique<LORsDevice>(std::move(pp_scannerDevice));
-}
-
 ProjectionDataDevice::ProjectionDataDevice(const Scanner& pr_scanner,
                                            const ProjectionData* pp_reference,
                                            int num_OSEM_subsets,
@@ -160,7 +149,7 @@ ProjectionDataDevice::ProjectionDataDevice(const Scanner& pr_scanner,
 	createBinIterators(num_OSEM_subsets);
 	createBatchSetups(shareOfMemoryToUse);
 
-	mp_LORs = std::make_unique<LORsDevice>(mr_scanner);
+	mp_LORs = std::make_unique<LORsDevice>();
 }
 
 void ProjectionDataDevice::createBinIterators(int num_OSEM_subsets)
@@ -200,45 +189,63 @@ void ProjectionDataDevice::createBatchSetups(float shareOfMemoryToUse)
 	}
 }
 
-void ProjectionDataDevice::loadEventLORs(size_t subsetId, size_t batchId,
-                                         const cudaStream_t* stream)
+void ProjectionDataDevice::prepareBatchLORs(size_t subsetId, size_t batchId,
+                                            GPULaunchConfig launchConfig)
 {
-	mp_LORs->loadEventLORs(*mp_binIteratorList.at(subsetId),
-	                       m_batchSetups.at(subsetId), subsetId, batchId,
-	                       *mp_reference, stream);
+	precomputeBatchLORs(subsetId, batchId);
+
+	// Must wait until previous operation using the device buffers is
+	// finished before loading another batch
+	cudaStreamSynchronize(*launchConfig.stream);  // Necessary bottleneck
+
+	loadPrecomputedLORsToDevice(launchConfig);
+}
+
+void ProjectionDataDevice::precomputeBatchLORs(size_t subsetId, size_t batchId)
+{
+	mp_LORs->precomputeBatchLORs(*mp_binIteratorList.at(subsetId),
+	                             m_batchSetups.at(subsetId), subsetId, batchId,
+	                             *mp_reference);
+}
+
+void ProjectionDataDevice::loadPrecomputedLORsToDevice(
+    GPULaunchConfig launchConfig)
+{
+	mp_LORs->loadPrecomputedLORsToDevice(launchConfig);
 }
 
 void ProjectionDataDevice::loadProjValuesFromReference(
-    const cudaStream_t* stream)
+    GPULaunchConfig launchConfig)
 {
-	loadProjValuesFromHostInternal(getReference(), nullptr, stream);
+	loadProjValuesFromHostInternal(getReference(), nullptr, launchConfig);
 }
 
 void ProjectionDataDevice::loadProjValuesFromHost(const ProjectionData* src,
-                                                  const cudaStream_t* stream)
+                                                  GPULaunchConfig launchConfig)
 {
-	loadProjValuesFromHostInternal(src, nullptr, stream);
+	loadProjValuesFromHostInternal(src, nullptr, launchConfig);
 }
 
 void ProjectionDataDevice::loadProjValuesFromHostHistogram(
-    const Histogram* histo, const cudaStream_t* stream)
+    const Histogram* histo, GPULaunchConfig launchConfig)
 {
-	loadProjValuesFromHostInternal(getReference(), histo, stream);
+	loadProjValuesFromHostInternal(getReference(), histo, launchConfig);
 }
 
 void ProjectionDataDevice::loadProjValuesFromHostInternal(
     const ProjectionData* src, const Histogram* histo,
-    const cudaStream_t* stream)
+    GPULaunchConfig launchConfig)
 {
 	if (src->isUniform() && histo == nullptr)
 	{
 		// No need to "getProjectionValue" everywhere, just fill the buffer with
 		// the same value
-		clearProjectionsDevice(getReference()->getProjectionValue(0), stream);
+		clearProjectionsDevice(getReference()->getProjectionValue(0),
+		                       launchConfig);
 	}
 	else
 	{
-		const size_t batchSize = getCurrentBatchSize();
+		const size_t batchSize = getLoadedBatchSize();
 		ASSERT_MSG(batchSize > 0,
 		           "The Batch size is 0. You didn't load the LORs "
 		           "before loading the projection values");
@@ -246,10 +253,10 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
 		m_tempBuffer.reAllocateIfNeeded(batchSize);
 		float* projValuesBuffer = m_tempBuffer.getPointer();
 
-		auto* binIter = mp_binIteratorList.at(getCurrentSubsetId());
+		auto* binIter = mp_binIteratorList.at(getLoadedSubsetId());
 		const size_t firstBatchSize =
-		    getBatchSetup(getCurrentSubsetId()).getBatchSize(0);
-		const size_t offset = getCurrentBatchId() * firstBatchSize;
+		    getBatchSetup(getLoadedSubsetId()).getBatchSize(0);
+		const size_t offset = getLoadedBatchId() * firstBatchSize;
 
 		size_t binIdx;
 		bin_t binId;
@@ -283,26 +290,26 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
 		}
 
 		Util::copyHostToDevice(getProjValuesDevicePointer(), projValuesBuffer,
-		                       batchSize, stream, true);
+		                       batchSize, launchConfig);
 	}
 }
 
 void ProjectionDataDevice::transferProjValuesToHost(
     ProjectionData* projDataDest, const cudaStream_t* stream) const
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	ASSERT_MSG(batchSize > 0, "The Batch size is 0. You didn't load the LORs "
 	                          "before loading the projection values");
 
 	m_tempBuffer.reAllocateIfNeeded(batchSize);
 	float* projValuesBuffer = m_tempBuffer.getPointer();
 	Util::copyDeviceToHost(projValuesBuffer, getProjValuesDevicePointer(),
-	                       batchSize, stream, true);
+	                       batchSize, {stream, true});
 
-	auto* binIter = mp_binIteratorList.at(getCurrentSubsetId());
+	auto* binIter = mp_binIteratorList.at(getLoadedSubsetId());
 	const size_t firstBatchSize =
-	    m_batchSetups.at(getCurrentSubsetId()).getBatchSize(0);
-	const size_t offset = getCurrentBatchId() * firstBatchSize;
+	    m_batchSetups.at(getLoadedSubsetId()).getBatchSize(0);
+	const size_t offset = getLoadedBatchId() * firstBatchSize;
 
 	size_t binIdx;
 	bin_t binId;
@@ -315,22 +322,32 @@ void ProjectionDataDevice::transferProjValuesToHost(
 	}
 }
 
-std::shared_ptr<ScannerDevice> ProjectionDataDevice::getScannerDevice() const
+size_t ProjectionDataDevice::getPrecomputedBatchSize() const
 {
-	return mp_LORs->getScannerDevice();
+	return mp_LORs->getPrecomputedBatchSize();
 }
 
-size_t ProjectionDataDevice::getCurrentBatchSize() const
+size_t ProjectionDataDevice::getPrecomputedBatchId() const
+{
+	return mp_LORs->getPrecomputedBatchId();
+}
+
+size_t ProjectionDataDevice::getPrecomputedSubsetId() const
+{
+	return mp_LORs->getPrecomputedSubsetId();
+}
+
+size_t ProjectionDataDevice::getLoadedBatchSize() const
 {
 	return mp_LORs->getLoadedBatchSize();
 }
 
-size_t ProjectionDataDevice::getCurrentBatchId() const
+size_t ProjectionDataDevice::getLoadedBatchId() const
 {
 	return mp_LORs->getLoadedBatchId();
 }
 
-size_t ProjectionDataDevice::getCurrentSubsetId() const
+size_t ProjectionDataDevice::getLoadedSubsetId() const
 {
 	return mp_LORs->getLoadedSubsetId();
 }
@@ -375,50 +392,63 @@ void ProjectionDataDevice::setProjectionValue(bin_t id, float val)
 
 void ProjectionDataDevice::clearProjections(float value)
 {
-	clearProjectionsDevice(value, nullptr);
+	clearProjectionsDevice(value, {nullptr, true});
 }
 
 void ProjectionDataDevice::clearProjectionsDevice(float value,
-                                                  const cudaStream_t* stream)
+                                                  GPULaunchConfig launchConfig)
 {
 	if (value == 0.0f)
 	{
-		clearProjectionsDevice(stream);
+		clearProjectionsDevice(launchConfig);
 		return;
 	}
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		clearProjections_kernel<<<launchParams.gridSize, launchParams.blockSize,
-		                          0, *stream>>>(
+		                          0, *launchConfig.stream>>>(
 		    getProjValuesDevicePointer(), value, static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
 		clearProjections_kernel<<<launchParams.gridSize,
 		                          launchParams.blockSize>>>(
 		    getProjValuesDevicePointer(), value, static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
-void ProjectionDataDevice::clearProjectionsDevice(const cudaStream_t* stream)
+void ProjectionDataDevice::clearProjectionsDevice(GPULaunchConfig launchConfig)
 {
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		cudaMemsetAsync(getProjValuesDevicePointer(), 0,
-		                sizeof(float) * getCurrentBatchSize(), *stream);
-		cudaStreamSynchronize(*stream);
+		                sizeof(float) * getLoadedBatchSize(),
+		                *launchConfig.stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
 		cudaMemset(getProjValuesDevicePointer(), 0,
-		           sizeof(float) * getCurrentBatchSize());
-		cudaDeviceSynchronize();
+		           sizeof(float) * getLoadedBatchSize());
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
@@ -427,24 +457,28 @@ void ProjectionDataDevice::divideMeasurements(
     const ProjectionData* measurements, const BinIterator* binIter)
 {
 	(void)binIter;  // Not needed as this class has its own BinIterators
-	divideMeasurementsDevice(measurements, nullptr);
+	divideMeasurementsDevice(measurements, {nullptr, true});
 }
 
 void ProjectionDataDevice::divideMeasurementsDevice(
-    const ProjectionData* measurements, const cudaStream_t* stream)
+    const ProjectionData* measurements, GPULaunchConfig launchConfig)
 {
 	const auto* measurements_device =
 	    dynamic_cast<const ProjectionDataDevice*>(measurements);
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		divideMeasurements_kernel<<<launchParams.gridSize,
-		                            launchParams.blockSize, 0, *stream>>>(
+		                            launchParams.blockSize, 0,
+		                            *launchConfig.stream>>>(
 		    measurements_device->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
@@ -452,23 +486,29 @@ void ProjectionDataDevice::divideMeasurementsDevice(
 		                            launchParams.blockSize>>>(
 		    measurements_device->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
-void ProjectionDataDevice::invertProjValuesDevice(const cudaStream_t* stream)
+void ProjectionDataDevice::invertProjValuesDevice(GPULaunchConfig launchConfig)
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		invertProjValues_kernel<<<launchParams.gridSize, launchParams.blockSize,
-		                          0, *stream>>>(getProjValuesDevicePointer(),
-		                                        getProjValuesDevicePointer(),
-		                                        static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		                          0, *launchConfig.stream>>>(
+		    getProjValuesDevicePointer(), getProjValuesDevicePointer(),
+		    static_cast<int>(batchSize));
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
@@ -476,71 +516,90 @@ void ProjectionDataDevice::invertProjValuesDevice(const cudaStream_t* stream)
 		                          launchParams.blockSize>>>(
 		    getProjValuesDevicePointer(), getProjValuesDevicePointer(),
 		    static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
 void ProjectionDataDevice::addProjValues(const ProjectionDataDevice* projValues,
-                                         const cudaStream_t* stream)
+                                         GPULaunchConfig launchConfig)
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		addProjValues_kernel<<<launchParams.gridSize, launchParams.blockSize, 0,
-		                       *stream>>>(
+		                       *launchConfig.stream>>>(
 		    projValues->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
 		addProjValues_kernel<<<launchParams.gridSize, launchParams.blockSize>>>(
 		    projValues->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
-void ProjectionDataDevice::convertToACFsDevice(const cudaStream_t* stream)
+void ProjectionDataDevice::convertToACFsDevice(GPULaunchConfig launchConfig)
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		convertToACFs_kernel<<<launchParams.gridSize, launchParams.blockSize, 0,
-		                       *stream>>>(getProjValuesDevicePointer(),
-		                                  getProjValuesDevicePointer(), 0.1f,
-		                                  static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		                       *launchConfig.stream>>>(
+		    getProjValuesDevicePointer(), getProjValuesDevicePointer(), 0.1f,
+		    static_cast<int>(batchSize));
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
 		convertToACFs_kernel<<<launchParams.gridSize, launchParams.blockSize>>>(
 		    getProjValuesDevicePointer(), getProjValuesDevicePointer(), 0.1f,
 		    static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
 void ProjectionDataDevice::multiplyProjValues(
-    const ProjectionDataDevice* projValues, const cudaStream_t* stream)
+    const ProjectionDataDevice* projValues, GPULaunchConfig launchConfig)
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		multiplyProjValues_kernel<<<launchParams.gridSize,
-		                            launchParams.blockSize, 0, *stream>>>(
+		                            launchParams.blockSize, 0,
+		                            *launchConfig.stream>>>(
 		    projValues->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
@@ -548,30 +607,40 @@ void ProjectionDataDevice::multiplyProjValues(
 		                            launchParams.blockSize>>>(
 		    projValues->getProjValuesDevicePointer(),
 		    getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
 
 void ProjectionDataDevice::multiplyProjValues(float scalar,
-                                              const cudaStream_t* stream)
+                                              GPULaunchConfig launchConfig)
 {
-	const size_t batchSize = getCurrentBatchSize();
+	const size_t batchSize = getLoadedBatchSize();
 	const auto launchParams = Util::initiateDeviceParameters(batchSize);
 
-	if (stream != nullptr)
+	if (launchConfig.stream != nullptr)
 	{
 		multiplyProjValues_kernel<<<launchParams.gridSize,
-		                            launchParams.blockSize, 0, *stream>>>(
+		                            launchParams.blockSize, 0,
+		                            *launchConfig.stream>>>(
 		    scalar, getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaStreamSynchronize(*stream);
+		if (launchConfig.synchronize)
+		{
+			cudaStreamSynchronize(*launchConfig.stream);
+		}
 	}
 	else
 	{
 		multiplyProjValues_kernel<<<launchParams.gridSize,
 		                            launchParams.blockSize>>>(
 		    scalar, getProjValuesDevicePointer(), static_cast<int>(batchSize));
-		cudaDeviceSynchronize();
+		if (launchConfig.synchronize)
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 	cudaCheckError();
 }
@@ -606,16 +675,6 @@ ProjectionDataDeviceOwned::ProjectionDataDeviceOwned(
     int num_OSEM_subsets, float shareOfMemoryToUse)
     : ProjectionDataDevice(pr_scanner, pp_reference, num_OSEM_subsets,
                            shareOfMemoryToUse)
-{
-	mp_projValues = std::make_unique<DeviceArray<float>>();
-}
-
-ProjectionDataDeviceOwned::ProjectionDataDeviceOwned(
-    std::shared_ptr<ScannerDevice> pp_scannerDevice,
-    const ProjectionData* pp_reference, int num_OSEM_subsets,
-    float shareOfMemoryToUse)
-    : ProjectionDataDevice(std::move(pp_scannerDevice), pp_reference,
-                           num_OSEM_subsets, shareOfMemoryToUse)
 {
 	mp_projValues = std::make_unique<DeviceArray<float>>();
 }
@@ -657,20 +716,23 @@ const float* ProjectionDataDeviceOwned::getProjValuesDevicePointer() const
 }
 
 bool ProjectionDataDeviceOwned::allocateForProjValues(
-    const cudaStream_t* stream)
+    GPULaunchConfig launchConfig)
 {
-	return mp_projValues->allocate(getCurrentBatchSize(), stream);
+	// Allocate projection value buffers based on the latest precomputed batch
+	//  size
+	return mp_projValues->allocate(getPrecomputedBatchSize(), launchConfig);
 }
 
 void ProjectionDataDeviceOwned::loadProjValuesFromHostInternal(
     const ProjectionData* src, const Histogram* histo,
-    const cudaStream_t* stream)
+    GPULaunchConfig launchConfig)
 {
 	if (!mp_projValues->isAllocated())
 	{
-		allocateForProjValues(stream);
+		allocateForProjValues(launchConfig);
 	}
-	ProjectionDataDevice::loadProjValuesFromHostInternal(src, histo, stream);
+	ProjectionDataDevice::loadProjValuesFromHostInternal(src, histo,
+	                                                     launchConfig);
 }
 
 ProjectionDataDeviceAlias::ProjectionDataDeviceAlias(
@@ -688,16 +750,6 @@ ProjectionDataDeviceAlias::ProjectionDataDeviceAlias(
     int num_OSEM_subsets, float shareOfMemoryToUse)
     : ProjectionDataDevice(pr_scanner, pp_reference, num_OSEM_subsets,
                            shareOfMemoryToUse),
-      mpd_devicePointer(nullptr)
-{
-}
-
-ProjectionDataDeviceAlias::ProjectionDataDeviceAlias(
-    std::shared_ptr<ScannerDevice> pp_scannerDevice,
-    const ProjectionData* pp_reference, int num_OSEM_subsets,
-    float shareOfMemoryToUse)
-    : ProjectionDataDevice(std::move(pp_scannerDevice), pp_reference,
-                           num_OSEM_subsets, shareOfMemoryToUse),
       mpd_devicePointer(nullptr)
 {
 }

--- a/yrt-pet/src/operators/DeviceSynchronized.cu
+++ b/yrt-pet/src/operators/DeviceSynchronized.cu
@@ -112,11 +112,9 @@ CUImageParams DeviceSynchronized::getCUImageParams(const ImageParams& imgParams)
 	return params;
 }
 
-DeviceSynchronized::DeviceSynchronized(bool p_synchronized,
-                               const cudaStream_t* pp_mainStream,
-                               const cudaStream_t* pp_auxStream)
+DeviceSynchronized::DeviceSynchronized(const cudaStream_t* pp_mainStream,
+                                       const cudaStream_t* pp_auxStream)
 {
-	m_synchronized = p_synchronized;
 	mp_mainStream = pp_mainStream;
 	mp_auxStream = pp_auxStream;
 }

--- a/yrt-pet/src/operators/DeviceSynchronized.cu
+++ b/yrt-pet/src/operators/DeviceSynchronized.cu
@@ -115,6 +115,22 @@ CUImageParams DeviceSynchronized::getCUImageParams(const ImageParams& imgParams)
 DeviceSynchronized::DeviceSynchronized(const cudaStream_t* pp_mainStream,
                                        const cudaStream_t* pp_auxStream)
 {
-	mp_mainStream = pp_mainStream;
-	mp_auxStream = pp_auxStream;
+	if (pp_mainStream != nullptr)
+	{
+		mp_mainStream = pp_mainStream;
+	}
+	else
+	{
+		mp_mainStreamPtr = std::make_unique<GPUStream>();
+		mp_mainStream = &mp_mainStreamPtr->getStream();
+	}
+	if (pp_auxStream != nullptr)
+	{
+		mp_auxStream = pp_auxStream;
+	}
+	else
+	{
+		mp_auxStreamPtr = std::make_unique<GPUStream>();
+		mp_auxStream = &mp_auxStreamPtr->getStream();
+	}
 }

--- a/yrt-pet/src/operators/OperatorProjectorDevice.cu
+++ b/yrt-pet/src/operators/OperatorProjectorDevice.cu
@@ -249,20 +249,21 @@ void OperatorProjectorDevice::applyAH(const Variable* in, Variable* out,
 
 		for (size_t batchId = 0; batchId < numBatches; batchId++)
 		{
-			deviceDat_in->loadPrecomputedLORsToDevice(
-			    {getMainStream(), false});  // debug
+			deviceDat_in->loadPrecomputedLORsToDevice({getMainStream(), false});
 			deviceDat_in->loadProjValuesFromReference({getMainStream(), false});
 			std::cout << "Backprojecting batch " << batchId + 1 << "/"
 			          << numBatches << "..." << std::endl;
+			cudaStreamSynchronize(*getMainStream());
 			applyAHOnLoadedBatch(*dat_in, *img_out, false);
+
 			if (batchId < numBatches - 1)
 			{
 				std::cout << "Loading batch " << batchId + 2 << "/"
 				          << numBatches << "..." << std::endl;
 				dat_in->precomputeBatchLORs(0, batchId + 1);
 			}
-			cudaStreamSynchronize(*getMainStream());
 		}
+		cudaStreamSynchronize(*getMainStream());
 	}
 
 	if (isImageDeviceOwned)

--- a/yrt-pet/src/operators/OperatorProjectorDevice.cu
+++ b/yrt-pet/src/operators/OperatorProjectorDevice.cu
@@ -143,7 +143,6 @@ void OperatorProjectorDevice::applyA(const Variable* in, Variable* out,
 
 	if (!isProjDataDeviceOwned)
 	{
-		std::cout << "Forward projecting current batch..." << std::endl;
 		applyAOnLoadedBatch(*img_in, *dat_out, synchronize);
 	}
 	else
@@ -237,7 +236,6 @@ void OperatorProjectorDevice::applyAH(const Variable* in, Variable* out,
 
 	if (!isProjDataDeviceOwned)
 	{
-		std::cout << "Backprojecting current batch..." << std::endl;
 		applyAHOnLoadedBatch(*dat_in, *img_out, synchronize);
 	}
 	else

--- a/yrt-pet/src/operators/OperatorProjectorDevice.cu
+++ b/yrt-pet/src/operators/OperatorProjectorDevice.cu
@@ -253,11 +253,8 @@ void OperatorProjectorDevice::applyAH(const Variable* in, Variable* out,
 			deviceDat_in->allocateForProjValues({getMainStream(), false});
 			deviceDat_in->loadProjValuesFromReference({getMainStream(), false});
 			deviceDat_in->loadPrecomputedLORsToDevice({getMainStream(), false});
-			if (getMainStream() != nullptr)
-			{
-				cudaStreamSynchronize(*getMainStream());
-			}
-			std::cout << "Backprojecting batch..." << std::endl;
+			std::cout << "Backprojecting batch " << batchId + 1 << "/"
+			          << numBatches << "..." << std::endl;
 			applyAHOnLoadedBatch(*dat_in, *img_out, false);
 		}
 	}

--- a/yrt-pet/src/operators/OperatorProjectorDevice.cu
+++ b/yrt-pet/src/operators/OperatorProjectorDevice.cu
@@ -243,17 +243,25 @@ void OperatorProjectorDevice::applyAH(const Variable* in, Variable* out,
 		// Iterate over all the batches of the current subset
 		const size_t numBatches = dat_in->getBatchSetup(0).getNumBatches();
 
+		std::cout << "Loading batch 1/" << numBatches << "..." << std::endl;
+		dat_in->precomputeBatchLORs(0, 0);
+		deviceDat_in->allocateForProjValues({getMainStream(), false});
+
 		for (size_t batchId = 0; batchId < numBatches; batchId++)
 		{
-			std::cout << "Loading batch " << batchId + 1 << "/" << numBatches
-			          << "..." << std::endl;
-			dat_in->precomputeBatchLORs(0, batchId);
-			deviceDat_in->allocateForProjValues({getMainStream(), false});
+			deviceDat_in->loadPrecomputedLORsToDevice(
+			    {getMainStream(), false});  // debug
 			deviceDat_in->loadProjValuesFromReference({getMainStream(), false});
-			deviceDat_in->loadPrecomputedLORsToDevice({getMainStream(), false});
 			std::cout << "Backprojecting batch " << batchId + 1 << "/"
 			          << numBatches << "..." << std::endl;
 			applyAHOnLoadedBatch(*dat_in, *img_out, false);
+			if (batchId < numBatches - 1)
+			{
+				std::cout << "Loading batch " << batchId + 2 << "/"
+				          << numBatches << "..." << std::endl;
+				dat_in->precomputeBatchLORs(0, batchId + 1);
+			}
+			cudaStreamSynchronize(*getMainStream());
 		}
 	}
 

--- a/yrt-pet/src/operators/OperatorProjectorDevice.cu
+++ b/yrt-pet/src/operators/OperatorProjectorDevice.cu
@@ -156,7 +156,7 @@ void OperatorProjectorDevice::applyA(const Variable* in, Variable* out,
 
 		for (size_t batchId = 0; batchId < numBatches; batchId++)
 		{
-			dat_out->loadPrecomputedLORsToDevice({getMainStream(), false});
+			dat_out->loadPrecomputedLORsToDevice({getMainStream(), true});
 
 			std::cout << "Forward projecting batch " << batchId + 1 << "/"
 			          << numBatches << "..." << std::endl;
@@ -171,7 +171,7 @@ void OperatorProjectorDevice::applyA(const Variable* in, Variable* out,
 				dat_out->precomputeBatchLORs(0, batchId + 1);
 			}
 			std::cout << "Transferring batch to Host..." << std::endl;
-			// This will force a synchronization
+			// This will force a necessary synchronization
 			dat_out->transferProjValuesToHost(hostDat_out, getMainStream());
 		}
 	}

--- a/yrt-pet/src/operators/OperatorPsfDevice.cu
+++ b/yrt-pet/src/operators/OperatorPsfDevice.cu
@@ -119,8 +119,8 @@ void OperatorPsfDevice::apply(const Variable* in, Variable* out,
 	if (img_in != nullptr)
 	{
 		// Input image is in host
-		inputImageDevice =
-		    std::make_unique<ImageDeviceOwned>(img_in->getParams());
+		inputImageDevice = std::make_unique<ImageDeviceOwned>(
+		    img_in->getParams(), getMainStream());
 		reinterpret_cast<ImageDeviceOwned*>(inputImageDevice.get())->allocate();
 		inputImageDevice->transferToDeviceMemory(img_in, synchronize);
 		inputImageDevice_ptr = inputImageDevice.get();
@@ -136,8 +136,8 @@ void OperatorPsfDevice::apply(const Variable* in, Variable* out,
 	if (img_out != nullptr)
 	{
 		// Input image is in host
-		outputImageDevice =
-		    std::make_unique<ImageDeviceOwned>(img_out->getParams());
+		outputImageDevice = std::make_unique<ImageDeviceOwned>(
+		    img_out->getParams(), getMainStream());
 		reinterpret_cast<ImageDeviceOwned*>(outputImageDevice.get())
 		    ->allocate();
 		outputImageDevice_ptr = outputImageDevice.get();
@@ -154,7 +154,19 @@ void OperatorPsfDevice::apply(const Variable* in, Variable* out,
 	// Transfer to host
 	if (img_out != nullptr)
 	{
-		outputImageDevice->transferToHostMemory(img_out, synchronize);
+		outputImageDevice->transferToHostMemory(img_out, false);
+	}
+
+	if (synchronize)
+	{
+		if (getMainStream() != nullptr)
+		{
+			cudaStreamSynchronize(*getMainStream());
+		}
+		else
+		{
+			cudaDeviceSynchronize();
+		}
 	}
 }
 

--- a/yrt-pet/src/operators/OperatorPsfDevice.cu
+++ b/yrt-pet/src/operators/OperatorPsfDevice.cu
@@ -148,7 +148,8 @@ void OperatorPsfDevice::apply(const Variable* in, Variable* out,
 		ASSERT_MSG(outputImageDevice_ptr, "Output is not an image");
 	}
 
-	convolveDevice<Transpose>(*inputImageDevice_ptr, *outputImageDevice_ptr);
+	convolveDevice<Transpose>(*inputImageDevice_ptr, *outputImageDevice_ptr,
+	                          false);
 
 	// Transfer to host
 	if (img_out != nullptr)

--- a/yrt-pet/src/recon/OSEMUpdater_GPU.cu
+++ b/yrt-pet/src/recon/OSEMUpdater_GPU.cu
@@ -37,7 +37,7 @@ void OSEMUpdater_GPU::computeSensitivityImage(ImageDevice& destImage) const
 		std::cout << "Batch " << batch + 1 << "/" << numBatchesInCurrentSubset
 		          << "..." << std::endl;
 		// Load LORs into device buffers
-		sensDataBuffer->loadEventLORs(currentSubset, batch,
+		sensDataBuffer->prepareBatchLORs(currentSubset, batch,
 		                              auxStream);
 		// Allocate for the projection values
 		const bool hasReallocated =
@@ -124,7 +124,7 @@ void OSEMUpdater_GPU::computeEMUpdateImage(const ImageDevice& inputImage,
 	{
 		std::cout << "Batch " << batch + 1 << "/" << numBatchesInCurrentSubset
 		          << "..." << std::endl;
-		measurementsDevice->loadEventLORs(currentSubset, batch,
+		measurementsDevice->prepareBatchLORs(currentSubset, batch,
 		                                  auxStream);
 
 		measurementsDevice->allocateForProjValues(auxStream);

--- a/yrt-pet/src/recon/OSEMUpdater_GPU.cu
+++ b/yrt-pet/src/recon/OSEMUpdater_GPU.cu
@@ -100,6 +100,11 @@ void OSEMUpdater_GPU::computeSensitivityImage(ImageDevice& destImage) const
 		// Backproject values
 		projector->applyAH(sensDataBuffer, &destImage, false);
 	}
+
+	if (mainStream != nullptr)
+	{
+		cudaStreamSynchronize(*mainStream);
+	}
 }
 
 void OSEMUpdater_GPU::computeEMUpdateImage(const ImageDevice& inputImage,
@@ -165,5 +170,10 @@ void OSEMUpdater_GPU::computeEMUpdateImage(const ImageDevice& inputImage,
 		}
 
 		projector->applyAH(tmpBufferDevice, &destImage, false);
+	}
+
+	if (mainStream != nullptr)
+	{
+		cudaStreamSynchronize(*mainStream);
 	}
 }

--- a/yrt-pet/src/recon/OSEM_CPU.cpp
+++ b/yrt-pet/src/recon/OSEM_CPU.cpp
@@ -273,13 +273,6 @@ void OSEM_CPU::endRecon()
 	mp_datTmp = nullptr;
 }
 
-void OSEM_CPU::loadBatch(int batchId, bool forRecon)
-{
-	// No-op on CPU
-	(void)forRecon;
-	(void)batchId;
-}
-
 void OSEM_CPU::loadSubset(int subsetId, bool forRecon)
 {
 	(void)forRecon;

--- a/yrt-pet/src/recon/OSEM_GPU.cu
+++ b/yrt-pet/src/recon/OSEM_GPU.cu
@@ -360,7 +360,7 @@ void OSEM_GPU::loadBatch(int batchId, bool forRecon)
 	          << std::endl;
 	if (forRecon)
 	{
-		mpd_dat->loadEventLORs(m_current_OSEM_subset, batchId,
+		mpd_dat->prepareBatchLORs(m_current_OSEM_subset, batchId,
 		                       getAuxStream());
 		mpd_dat->allocateForProjValues(getAuxStream());
 		mpd_dat->loadProjValuesFromReference(getAuxStream());
@@ -369,7 +369,7 @@ void OSEM_GPU::loadBatch(int batchId, bool forRecon)
 	}
 	else
 	{
-		mpd_tempSensDataInput->loadEventLORs(m_current_OSEM_subset, batchId,
+		mpd_tempSensDataInput->prepareBatchLORs(m_current_OSEM_subset, batchId,
 		                                     getAuxStream());
 		mpd_tempSensDataInput->allocateForProjValues(getAuxStream());
 		mpd_tempSensDataInput->loadProjValuesFromReference(getAuxStream());

--- a/yrt-pet/src/recon/OSEM_GPU.cu
+++ b/yrt-pet/src/recon/OSEM_GPU.cu
@@ -167,14 +167,19 @@ void OSEM_GPU::allocateForRecon()
 	    std::make_unique<ImageDeviceOwned>(getImageParams(), getAuxStream());
 	mpd_mlemImageTmpEMRatio =
 	    std::make_unique<ImageDeviceOwned>(getImageParams(), getAuxStream());
-	mpd_mlemImageTmpPsf =
-	    std::make_unique<ImageDeviceOwned>(getImageParams(), getAuxStream());
 	mpd_sensImageBuffer =
 	    std::make_unique<ImageDeviceOwned>(getImageParams(), getAuxStream());
+
 	mpd_mlemImage->allocate(false);
 	mpd_mlemImageTmpEMRatio->allocate(false);
-	mpd_mlemImageTmpPsf->allocate(false);
 	mpd_sensImageBuffer->allocate(false);
+
+	if (flagImagePSF)
+	{
+		mpd_mlemImageTmpPsf =
+			std::make_unique<ImageDeviceOwned>(getImageParams(), getAuxStream());
+		mpd_mlemImageTmpPsf->allocate(false);
+	}
 
 	// Initialize the MLEM image values to non-zero
 	if (initialEstimate != nullptr)
@@ -202,7 +207,7 @@ void OSEM_GPU::allocateForRecon()
 	{
 		std::cout << "Summing sensitivity images to generate mask image..."
 		          << std::endl;
-		// TODO NOW: Maybe this will need to be debugged (needs care)
+
 		for (int i = 0; i < num_OSEM_subsets; ++i)
 		{
 			mpd_sensImageBuffer->copyFromHostImage(getSensitivityImage(i),
@@ -295,6 +300,7 @@ ImageBase* OSEM_GPU::getMLEMImageTmpBuffer(TemporaryImageSpaceBufferType type)
 	}
 	if (type == TemporaryImageSpaceBufferType::PSF)
 	{
+		ASSERT(flagImagePSF);
 		return mpd_mlemImageTmpPsf.get();
 	}
 	throw std::runtime_error("Unknown Temporary image type");

--- a/yrt-pet/src/recon/OSEM_GPU.cu
+++ b/yrt-pet/src/recon/OSEM_GPU.cu
@@ -387,9 +387,7 @@ void OSEM_GPU::computeEMUpdateImage(const ImageBase& inputImage,
 
 const cudaStream_t* OSEM_GPU::getAuxStream() const
 {
-	// TODO: Add parallel loading
-	// return &m_auxStream.getStream();
-	return &m_mainStream.getStream();
+	return &m_auxStream.getStream();
 }
 
 const cudaStream_t* OSEM_GPU::getMainStream() const


### PR DESCRIPTION
This PR includes vast changes encompassing the parallelization of batch loading with
forward or backward projection
- Add object named GPULaunchConfig to determine whether a GPU function is to be
called with synchronization or not, and with which stream (if there is a stream)
- Use this object as argument for many Device-side operations (in all the wrappers)
- Use this object to determine how the parallelization occurs in the projectors and in the OSEM
- Change the way LORsDevice stores its logic in order to implement the parallel loading correctly
    - This means we now track the "precomputed" batch Id, AND the "loaded" batchId.
    - The precomputed batch Id refers to the batch currently loaded in the temporary buffers ready to be loaded into the device
    - The loaded batch Id refers to the batch currently loaded in the device buffers.
- (Breaking change) Rename loadEventLORs to prepareBatchLORs as the name was highly misleading

This PR **DOES NOT** include multiple batch loading, as this is would require many more design decisions.

