### PR TITLE
Hotfix: Plugins not properly loading parameters into the registry

### DIFF
--- a/yrt-pet/executables/conversion/ConvertToHistogram.cpp
+++ b/yrt-pet/executables/conversion/ConvertToHistogram.cpp
@@ -47,14 +47,14 @@ int main(int argc, char** argv)
 		                          false, IO::TypeOfArgument::BOOL, false,
 		                          outputGroup);
 
+		PluginOptionsHelper::addOptionsFromPlugins(
+			registry, Plugin::InputFormatsChoice::ALL);
+
 		// Load configuration
 		IO::ArgumentReader config{
 		    registry,
 		    "Convert any input format to a histogram (either fully 3D "
 		    "dense histogram or sparse histogram)"};
-
-		PluginOptionsHelper::addOptionsFromPlugins(
-		    registry, Plugin::InputFormatsChoice::ALL);
 
 		if (!config.loadFromCommandLine(argc, argv))
 		{

--- a/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
+++ b/yrt-pet/executables/conversion/ConvertToListModeLUT.cpp
@@ -44,13 +44,14 @@ int main(int argc, char** argv)
 		registry.registerArgument("out", "Output histogram filename", true,
 		                          IO::TypeOfArgument::STRING, "", outputGroup,
 		                          "o");
+
+		PluginOptionsHelper::addOptionsFromPlugins(
+			registry, Plugin::InputFormatsChoice::ONLYLISTMODES);
+
 		// Load configuration
 		IO::ArgumentReader config{
 		    registry, "Convert a list-mode input (of any format, including "
 		              "plugin formats) to a ListModeLUT format"};
-
-		PluginOptionsHelper::addOptionsFromPlugins(
-		    registry, Plugin::InputFormatsChoice::ONLYLISTMODES);
 
 		if (!config.loadFromCommandLine(argc, argv))
 		{

--- a/yrt-pet/executables/conversion/CumulateHistograms.cpp
+++ b/yrt-pet/executables/conversion/CumulateHistograms.cpp
@@ -48,15 +48,15 @@ int main(int argc, char** argv)
 		                          false, IO::TypeOfArgument::BOOL, false,
 		                          outputGroup);
 
+		PluginOptionsHelper::addOptionsFromPlugins(
+			registry, Plugin::InputFormatsChoice::ONLYHISTOGRAMS);
+
 		// Load configuration
 		IO::ArgumentReader config{
 		    registry,
 		    "Take several histograms (of any format, including plugin formats) "
 		    "and accumulate them into a total histogram (either fully 3D "
 		    "dense histogram or sparse histogram)"};
-
-		PluginOptionsHelper::addOptionsFromPlugins(
-		    registry, Plugin::InputFormatsChoice::ONLYHISTOGRAMS);
 
 		if (!config.loadFromCommandLine(argc, argv))
 		{


### PR DESCRIPTION
The plugin options must be loaded into registry before the registry is used to create the options in the command line. This fixes some issues with some of the less-used executables.