### PR TITLE
Fix issue with randoms correction from List-mode data not being applied

### DIFF
--- a/yrt-pet/include/datastruct/projection/ProjectionData.hpp
+++ b/yrt-pet/include/datastruct/projection/ProjectionData.hpp
@@ -43,6 +43,7 @@ public:
 	virtual timestamp_t getTimestamp(bin_t id) const;
 	virtual frame_t getFrame(bin_t id) const;
 	virtual bool isUniform() const;
+	virtual bool hasRandomsEstimates() const;
 	virtual float getRandomsEstimate(bin_t id) const;
 	// Time-of-flight
 	virtual bool hasTOF() const;

--- a/yrt-pet/include/datastruct/projection/ProjectionList.hpp
+++ b/yrt-pet/include/datastruct/projection/ProjectionList.hpp
@@ -35,6 +35,7 @@ public:
 	timestamp_t getTimestamp(bin_t id) const override;
 	size_t getNumFrames() const override;
 	bool isUniform() const override;
+	bool hasRandomsEstimates() const override;
 	float getRandomsEstimate(bin_t id) const override;
 	bool hasTOF() const override;
 	float getTOFValue(bin_t id) const override;

--- a/yrt-pet/include/recon/Corrector.hpp
+++ b/yrt-pet/include/recon/Corrector.hpp
@@ -58,7 +58,7 @@ public:
 	bool doesHardwareACFComeFromHistogram() const;
 
 	// For reconstruction
-	bool hasAdditiveCorrection() const;
+	bool hasAdditiveCorrection(const ProjectionData& measurements) const;
 	bool hasInVivoAttenuation() const;
 	const Image* getInVivoAttenuationImage() const;
 	bool doesTotalACFComeFromHistogram() const;

--- a/yrt-pet/src/datastruct/projection/ProjectionData.cpp
+++ b/yrt-pet/src/datastruct/projection/ProjectionData.cpp
@@ -96,6 +96,11 @@ bool ProjectionData::isUniform() const
 	return false;
 }
 
+bool ProjectionData::hasRandomsEstimates() const
+{
+	return false;
+}
+
 bool ProjectionData::hasMotion() const
 {
 	return false;

--- a/yrt-pet/src/datastruct/projection/ProjectionList.cpp
+++ b/yrt-pet/src/datastruct/projection/ProjectionList.cpp
@@ -106,6 +106,11 @@ bool ProjectionList::isUniform() const
 	return false;
 }
 
+bool ProjectionList::hasRandomsEstimates() const
+{
+	return mp_reference->hasRandomsEstimates();
+}
+
 float ProjectionList::getRandomsEstimate(bin_t id) const
 {
 	return mp_reference->getRandomsEstimate(id);

--- a/yrt-pet/src/recon/Corrector.cpp
+++ b/yrt-pet/src/recon/Corrector.cpp
@@ -281,9 +281,10 @@ bool Corrector::hasMultiplicativeCorrection() const
 	return hasHardwareAttenuation() || hasSensitivityHistogram();
 }
 
-bool Corrector::hasAdditiveCorrection() const
+bool Corrector::hasAdditiveCorrection(const ProjectionData& measurements) const
 {
-	return mp_randoms != nullptr || mp_scatter != nullptr;
+	return mp_randoms != nullptr || mp_scatter != nullptr ||
+	       measurements.hasRandomsEstimates();
 }
 
 bool Corrector::mustInvertSensitivity() const

--- a/yrt-pet/src/recon/Corrector_CPU.cpp
+++ b/yrt-pet/src/recon/Corrector_CPU.cpp
@@ -16,7 +16,8 @@ Corrector_CPU::Corrector_CPU(const Scanner& pr_scanner) : Corrector(pr_scanner)
 void Corrector_CPU::precomputeAdditiveCorrectionFactors(
     const ProjectionData& measurements)
 {
-	ASSERT_MSG(hasAdditiveCorrection(), "No additive corrections needed");
+	ASSERT_MSG(hasAdditiveCorrection(measurements),
+	           "No additive corrections needed");
 
 	const ProjectionData* measurementsPtr = &measurements;
 

--- a/yrt-pet/src/recon/Corrector_GPU.cu
+++ b/yrt-pet/src/recon/Corrector_GPU.cu
@@ -18,7 +18,7 @@ Corrector_GPU::Corrector_GPU(const Scanner& pr_scanner)
 void Corrector_GPU::precomputeAdditiveCorrectionFactors(
     const ProjectionData& measurements)
 {
-	ASSERT_MSG(hasAdditiveCorrection(), "No additive corrections needed");
+	ASSERT_MSG(hasAdditiveCorrection(measurements), "No additive corrections needed");
 
 	auto additiveCorrections =
 	    std::make_unique<ProjectionListOwned>(&measurements);

--- a/yrt-pet/src/recon/OSEMUpdater_CPU.cpp
+++ b/yrt-pet/src/recon/OSEMUpdater_CPU.cpp
@@ -63,12 +63,13 @@ void OSEMUpdater_CPU::computeEMUpdateImage(const Image& inputImage,
 	const Image* inputImagePtr = &inputImage;
 	Image* destImagePtr = &destImage;
 
-	const bool hasAdditiveCorrection = corrector.hasAdditiveCorrection();
-	const bool hasInVivoAttenuation = corrector.hasInVivoAttenuation();
-
 	ASSERT(projector != nullptr);
 	ASSERT(binIter != nullptr);
 	ASSERT(measurements != nullptr);
+
+	const bool hasAdditiveCorrection =
+	    corrector.hasAdditiveCorrection(*measurements);
+	const bool hasInVivoAttenuation = corrector.hasInVivoAttenuation();
 
 	if (hasAdditiveCorrection)
 	{

--- a/yrt-pet/src/recon/OSEMUpdater_GPU.cu
+++ b/yrt-pet/src/recon/OSEMUpdater_GPU.cu
@@ -146,7 +146,7 @@ void OSEMUpdater_GPU::computeEMUpdateImage(const ImageDevice& inputImage,
 
 		projector->applyA(&inputImage, tmpBufferDevice, false);
 
-		if (corrector.hasAdditiveCorrection())
+		if (corrector.hasAdditiveCorrection(*measurementsDevice))
 		{
 			corrector.loadAdditiveCorrectionFactorsToTemporaryDeviceBuffer(
 			    {mainStream, false});

--- a/yrt-pet/src/recon/OSEM_CPU.cpp
+++ b/yrt-pet/src/recon/OSEM_CPU.cpp
@@ -262,7 +262,7 @@ void OSEM_CPU::allocateForRecon()
 	}
 	mp_mlemImageTmp->setValue(0.0f);
 
-	if (mp_corrector->hasAdditiveCorrection())
+	if (mp_corrector->hasAdditiveCorrection(*dataInput))
 	{
 		mp_corrector->precomputeAdditiveCorrectionFactors(*dataInput);
 	}

--- a/yrt-pet/src/recon/OSEM_GPU.cu
+++ b/yrt-pet/src/recon/OSEM_GPU.cu
@@ -262,7 +262,7 @@ void OSEM_GPU::allocateForRecon()
 	// Make sure the corrector buffer is properly defined
 	mp_corrector->initializeTemporaryDeviceBuffer(mpd_dat.get());
 
-	if (mp_corrector->hasAdditiveCorrection())
+	if (mp_corrector->hasAdditiveCorrection(*dataInput))
 	{
 		mp_corrector->precomputeAdditiveCorrectionFactors(*dataInput);
 	}


### PR DESCRIPTION
In the previous implementation, randoms correction would only be considered if it came from a histogram due to the multiple checks from the `Corrector` object being done against `Histogram` objects. This is mistaken as it should also question whether the list-mode has event-by-event randoms estimates.
