### PR TITLE
Load randoms

### DIFF
--- a/yrt-pet/include/yrt-pet/datastruct/projection/ProjectionDataDevice.cuh
+++ b/yrt-pet/include/yrt-pet/datastruct/projection/ProjectionDataDevice.cuh
@@ -56,11 +56,23 @@ public:
 	void precomputeBatchLORs(int subsetId, int batchId);
 	void loadPrecomputedLORsToDevice(GPULaunchConfig launchConfig);
 
+	// Gather the projection values from the reference ProjectionData object and
+	// store them on the GPU buffer
 	void loadProjValuesFromReference(GPULaunchConfig launchConfig);
+	// Gather the projection values from any given ProjectionData object and
+	// store them on the GPU buffer
 	void loadProjValuesFromHost(const ProjectionData* src,
 	                            GPULaunchConfig launchConfig);
+	// Gather the randoms estimates from any given ProjectionData object and
+	// store them on the GPU buffer
+	void loadProjValuesFromHostRandoms(const ProjectionData* src,
+	                                   GPULaunchConfig launchConfig);
+	// Gather the projection values from any given Histogram object (using the
+	// associated histogram bins) and store them on the GPU buffer
 	void loadProjValuesFromHostHistogram(const Histogram* histo,
 	                                     GPULaunchConfig launchConfig);
+	// Transfer the projection values on the device into a host-side
+	// ProjectionData object
 	void transferProjValuesToHost(ProjectionData* projDataDest,
 	                              const cudaStream_t* stream = nullptr) const;
 
@@ -109,8 +121,10 @@ public:
 	static constexpr float DefaultMemoryShare = 0.9f;
 
 protected:
+	// Function overridden by the Owned vs Alias pattern
 	virtual void loadProjValuesFromHostInternal(const ProjectionData* src,
 	                                            const Histogram* histo,
+	                                            bool gatherRandoms,
 	                                            GPULaunchConfig launchConfig);
 
 	// For Host->Device data transfers
@@ -121,6 +135,11 @@ protected:
 	std::vector<const BinIterator*> mp_binIteratorList;
 
 private:
+	// Helper with all the logic
+	template <bool GatherRandoms = false>
+	void loadProjValuesFromHostInternal(const ProjectionData* src,
+	                                    const Histogram* histo,
+	                                    GPULaunchConfig launchConfig);
 	void createBinIterators(int num_OSEM_subsets);
 	void createBatchSetups(float shareOfMemoryToUse);
 
@@ -163,6 +182,7 @@ public:
 protected:
 	void loadProjValuesFromHostInternal(const ProjectionData* src,
 	                                    const Histogram* histo,
+	                                    bool gatherRandoms,
 	                                    GPULaunchConfig launchConfig) override;
 
 private:

--- a/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
+++ b/yrt-pet/src/datastruct/projection/ProjectionDataDevice.cu
@@ -268,8 +268,11 @@ void ProjectionDataDevice::loadProjValuesFromHostInternal(
     const ProjectionData* src, const Histogram* histo, bool gatherRandoms,
     GPULaunchConfig launchConfig)
 {
+	ASSERT(src != nullptr);
 	if (gatherRandoms)
 	{
+		ASSERT_MSG(src->hasRandomsEstimates(),
+		           "Source projection data has no randoms estimates");
 		loadProjValuesFromHostInternal<true>(src, histo, launchConfig);
 	}
 	else

--- a/yrt-pet/src/operators/OperatorProjector.cpp
+++ b/yrt-pet/src/operators/OperatorProjector.cpp
@@ -128,8 +128,8 @@ void OperatorProjector::applyAH(const Variable* in, Variable* out)
 		    dat->getProjectionProperties(bin);
 
 		float projValue = dat->getProjectionValue(bin);
-		// TODO: Maybe this needs to be removed (will break previous recons)
-		if (std::abs(projValue) < SMALL)
+
+		if (std::abs(projValue) == 0.0f)
 		{
 			continue;
 		}

--- a/yrt-pet/unit_tests/operators/test_PSF.cpp
+++ b/yrt-pet/unit_tests/operators/test_PSF.cpp
@@ -6,6 +6,7 @@
 #include "../unit_tests/test_utils.hpp"
 #include "yrt-pet/operators/OperatorPsf.hpp"
 #include "yrt-pet/operators/OperatorVarPsf.hpp"
+#include "yrt-pet/utils/Assert.hpp"
 
 #if BUILD_CUDA
 #include "yrt-pet/operators/OperatorPsfDevice.cuh"


### PR DESCRIPTION
- Remove the discarding of low values for backprojections on the CPU
- Add function to load the randoms into the GPU
- Fix `include` error when compiling without CUDA